### PR TITLE
drop support for node  < 15

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [15.x, 16.x, 18.x, 19.x]
+        node-version: [16.x, 18.x, 19.x]
     steps:
     - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
Drop support for node.js version < 15