### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
 
 name: Node.js Package
+permissions:
+  contents: read
 
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/StanleyMasinde/mevn-orm/security/code-scanning/3](https://github.com/StanleyMasinde/mevn-orm/security/code-scanning/3)

In general, the fix is to explicitly declare least-privilege `GITHUB_TOKEN` permissions for this workflow. Since neither job appears to need to write to the repository itself (no pushes, PR updates, etc.), we can safely set `contents: read` at the workflow level, which will apply to both `build` and `publish-npm` jobs. If in the future a job requires additional permissions, they can be set more specifically on that job.

The single best fix, without changing functionality, is to add a root-level `permissions` block right after the `name:` line (or anywhere at the top level before `jobs:`), specifying `contents: read`. The `publish-npm` job uses an npm auth token via `NODE_AUTH_TOKEN`, not `GITHUB_TOKEN`, so it does not require write permissions on repository contents. No other scopes appear necessary. Only `.github/workflows/npm-publish.yml` needs editing, and no additional imports or methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
