### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -3,6 +3,9 @@
 
 name: Node.js CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/StanleyMasinde/mevn-orm/security/code-scanning/2](https://github.com/StanleyMasinde/mevn-orm/security/code-scanning/2)

To fix the problem, explicitly declare restricted `GITHUB_TOKEN` permissions in the workflow. Since this job only needs to read the repository contents to run tests and builds, we can set `contents: read` at the workflow level, which applies to all jobs. No steps in the `build` job require write access (no pushing commits, creating releases, or modifying issues/PRs), so read-only contents access is sufficient and respects least-privilege.

The best minimal fix is to add a root-level `permissions` block after the `name:` and before `on:` in `.github/workflows/node.js.yml`. This will restrict `GITHUB_TOKEN` to `contents: read` for all jobs that do not override permissions. No imports, methods, or other code changes are needed; only the YAML needs updating.

Specifically:
- Edit `.github/workflows/node.js.yml`.
- Insert:

```yaml
permissions:
  contents: read
```

between the existing `name: Node.js CI` (line 4) and the `on:` block (line 6). Indentation must align with other top-level keys.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
