### PR TITLE
fix: honour table overrides in static query methods

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -17,6 +17,7 @@ import {
 	migrateCurrentVersion,
 	migrateList,
 } from './src/model.js'
+import { getTableName, toSnakeCase } from './src/inflect.js'
 
 export {
 	Model,
@@ -36,4 +37,6 @@ export {
 	migrateRollback,
 	migrateCurrentVersion,
 	migrateList,
+	getTableName,
+	toSnakeCase,
 }

--- a/src/model.ts
+++ b/src/model.ts
@@ -19,9 +19,17 @@ class Model {
 
 	#private: string[]
 
-	static currentTable: string = getTableName(this.name)
+	static get currentTable(): string {
+		return this.resolveTable()
+	}
+
 	// `where()` stores a static scoped query consumed by `first()`.
 	static currentQuery: Knex.QueryBuilder<Row, Row[]> | undefined
+
+	/** Resolves the table name for this model, honouring subclass `table` overrides. */
+	static resolveTable(this: typeof Model): string {
+		return new this().table
+	}
 
 	fillable: string[]
 	hidden: string[]
@@ -100,7 +108,7 @@ class Model {
 	/** Updates rows in the model table, optionally scoped by `where()`. */
 	static async update(properties: Row): Promise<number | undefined> {
 		try {
-			const table = getTableName(this.name)
+			const table = this.resolveTable()
 			const query = this.currentQuery ?? getDB()(table)
 			return await query.update(properties)
 		} catch (error) {
@@ -113,7 +121,7 @@ class Model {
 	/** Deletes rows in the model table, optionally scoped by `where()`. */
 	static async destroy(): Promise<number | undefined> {
 		try {
-			const table = getTableName(this.name)
+			const table = this.resolveTable()
 			const query = this.currentQuery ?? getDB()(table)
 			return await query.delete()
 		} catch (error) {
@@ -125,7 +133,7 @@ class Model {
 
 	/** Finds a single model by primary key. */
 	static async find<T extends typeof Model>(this: T, id: number | string, columns: string | string[] = '*'): Promise<InstanceType<T> | null> {
-		const table = getTableName(this.name)
+		const table = this.resolveTable()
 
 		try {
 			const fields = await getDB()(table).where({ id }).first<Row>(columns as never)
@@ -147,7 +155,7 @@ class Model {
 
 	/** Creates and returns a single model record. */
 	static async create<T extends typeof Model>(this: T, properties: Row): Promise<InstanceType<T>> {
-		const table = getTableName(this.name)
+		const table = this.resolveTable()
 
 		try {
 			const inserted = await getDB()(table).insert(properties)
@@ -185,7 +193,7 @@ class Model {
 
 	/** Returns the first matching row or creates it with merged values when missing. */
 	static async firstOrCreate<T extends typeof Model>(this: T, attributes: Row, values: Row = {}): Promise<InstanceType<T>> {
-		const table = getTableName(this.name)
+		const table = this.resolveTable()
 		try {
 			const record = await getDB()(table).where(attributes).first<Row>()
 			if (record) {
@@ -201,7 +209,7 @@ class Model {
 
 	/** Applies a query scope used by chained static query methods. */
 	static where<T extends typeof Model>(this: T, conditions: Row = {}): T {
-		const table = getTableName(this.name)
+		const table = this.resolveTable()
 		this.currentQuery = getDB()(table).where(conditions) as Knex.QueryBuilder<Row, Row[]>
 		return this
 	}
@@ -209,7 +217,7 @@ class Model {
 	/** Returns the first model for the current scope (or table if unscoped). */
 	static async first<T extends typeof Model>(this: T, columns: string | string[] = '*'): Promise<InstanceType<T> | null> {
 		try {
-			const table = getTableName(this.name)
+			const table = this.resolveTable()
 			const query = this.currentQuery ?? getDB()(table)
 			const rows = await query.first<Row>(columns as never)
 			return rows ? new this(rows) as InstanceType<T> : null
@@ -223,7 +231,7 @@ class Model {
 	/** Returns all models for the current scope (or table if unscoped). */
 	static async all<T extends typeof Model>(this: T, columns: string | string[] = '*'): Promise<InstanceType<T>[]> {
 		try {
-			const table = getTableName(this.name)
+			const table = this.resolveTable()
 			const query = this.currentQuery ?? getDB()(table)
 			const rows = await query.select<Row[]>(columns as never)
 			return rows.map((row) => new this(row) as InstanceType<T>)
@@ -237,7 +245,7 @@ class Model {
 	/** Returns a row count for the current scope (or table if unscoped). */
 	static async count(this: typeof Model, column = '*'): Promise<number> {
 		try {
-			const table = getTableName(this.name)
+			const table = this.resolveTable()
 			const query = this.currentQuery ?? getDB()(table)
 			const result = await query.count<{ count: string | number }>({ count: column }).first()
 			if (!result) {

--- a/test/inflect.test.ts
+++ b/test/inflect.test.ts
@@ -9,7 +9,10 @@ describe('inflect', () => {
 	})
 
 	it('pluralizes snake_case table names', () => {
+		expect(getTableName('PasswordReset')).toBe('password_resets')
 		expect(getTableName('PasswordResetToken')).toBe('password_reset_tokens')
+		expect(getTableName('SystemEvent')).toBe('system_events')
+		expect(getTableName('SystemEventDeadLetter')).toBe('system_event_dead_letters')
 		expect(getTableName('User')).toBe('users')
 		expect(getTableName('Farmer')).toBe('farmers')
 	})

--- a/test/model.test.ts
+++ b/test/model.test.ts
@@ -65,6 +65,11 @@ class PasswordResetToken extends Model {
 	override fillable = ['user_id', 'token']
 }
 
+class PasswordReset extends Model {
+	override table = 'password_reset_tokens'
+	override fillable = ['user_id', 'token']
+}
+
 describe('#Model tests', () => {
 	it('#migration api supports generation and execution', async () => {
 		const directory = mkdtempSync(join(tmpdir(), 'mevn-orm-migrations-'))
@@ -221,6 +226,30 @@ describe('#Model tests', () => {
 		expect(belongsToRelation).toBeInstanceOf(BelongsToRelation)
 		expect(typeof belongsToRelation.where).toBe('function')
 		expect(typeof belongsToRelation.first).toBe('function')
+	})
+
+	it('#static queries honour explicit table overrides', async () => {
+		const db = getDB()
+		await db.schema.dropTableIfExists('password_reset_tokens')
+		await db.schema.createTable('password_reset_tokens', (table) => {
+			table.bigIncrements('id')
+			table.bigInteger('user_id')
+			table.string('token')
+		})
+
+		const created = await PasswordReset.create({ user_id: 42, token: 'override-token' }) as PasswordReset
+		expect(created).toHaveProperty('id')
+		expect(created).toHaveProperty('token', 'override-token')
+
+		const found = await PasswordReset.find(created.id as number)
+		expect(found).toHaveProperty('user_id', 42)
+		expect(found).toHaveProperty('token', 'override-token')
+
+		const queried = await PasswordReset.where({ user_id: 42 }).first()
+		expect(queried).toHaveProperty('token', 'override-token')
+
+		expect(PasswordReset.resolveTable()).toBe('password_reset_tokens')
+		expect(PasswordReset.currentTable).toBe('password_reset_tokens')
 	})
 
 	it('#camelCase model names resolve to snake_case table names', async () => {


### PR DESCRIPTION
## Summary

Fixes #273. Static query methods (`create`, `find`, `where`, `first`, `all`, `count`, `update`, `destroy`, `firstOrCreate`) now resolve table names through a single `Model.resolveTable()` helper instead of calling `getTableName(this.name)` directly.

`resolveTable()` instantiates the model subclass and reads its `table` property, so explicit `override table = '...'` declarations are honoured on every static entry point — matching the behaviour instance methods already had.

## Changes

- Add `Model.resolveTable()` and route all static query paths through it
- Make `Model.currentTable` a getter backed by `resolveTable()`
- Export `getTableName` and `toSnakeCase` from the package entry for debugging
- Expand inflection tests for compound names (`PasswordReset`, `SystemEvent`, etc.)
- Add integration test verifying `create`, `find`, and `where().first()` hit an overridden table

## Test plan

- [x] `pnpm test` — 32 tests pass
- [x] `pnpm typecheck`
- [x] `pnpm build`