### PR TITLE
feat: add orderBy, limit, and offset to static query builder

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -31,6 +31,16 @@ class Model {
 		return new this().table
 	}
 
+	/** Returns the active scoped query, initialising one against the model table when absent. */
+	static ensureCurrentQuery(this: typeof Model): Knex.QueryBuilder<Row, Row[]> {
+		if (!this.currentQuery) {
+			const table = this.resolveTable()
+			this.currentQuery = getDB()(table) as Knex.QueryBuilder<Row, Row[]>
+		}
+
+		return this.currentQuery
+	}
+
 	fillable: string[]
 	hidden: string[]
 	modelName: string
@@ -211,6 +221,24 @@ class Model {
 	static where<T extends typeof Model>(this: T, conditions: Row = {}): T {
 		const table = this.resolveTable()
 		this.currentQuery = getDB()(table).where(conditions) as Knex.QueryBuilder<Row, Row[]>
+		return this
+	}
+
+	/** Appends an `orderBy` clause to the current scoped query. */
+	static orderBy<T extends typeof Model>(this: T, column: string, direction: 'asc' | 'desc' = 'asc'): T {
+		this.ensureCurrentQuery().orderBy(column, direction)
+		return this
+	}
+
+	/** Appends a `limit` clause to the current scoped query. */
+	static limit<T extends typeof Model>(this: T, count: number): T {
+		this.ensureCurrentQuery().limit(count)
+		return this
+	}
+
+	/** Appends an `offset` clause to the current scoped query. */
+	static offset<T extends typeof Model>(this: T, count: number): T {
+		this.ensureCurrentQuery().offset(count)
 		return this
 	}
 

--- a/test/model.test.ts
+++ b/test/model.test.ts
@@ -350,6 +350,42 @@ describe('#Model tests', () => {
 		expect(parentFarmer).toHaveProperty('id', farm.farmer_id)
 	})
 
+	it('#orderBy sorts results at the database level', async () => {
+		const farmers = await Farmer.orderBy('name', 'asc').all()
+		const names = farmers.map((farmer) => farmer.name)
+		expect(names).toEqual([...names].sort())
+	})
+
+	it('#where and orderBy compose on the static query builder', async () => {
+		const owner = await Farmer.create({
+			name: 'Order Owner',
+			email: `order-owner-${Date.now()}@mail.test`,
+			password: faker.internet.password()
+		}) as Farmer
+		await Farm.create({ farmer_id: owner.id, name: 'Zebra Farm' })
+		await Farm.create({ farmer_id: owner.id, name: 'Alpha Farm' })
+
+		const farms = await Farm.where({ farmer_id: owner.id }).orderBy('name', 'asc').all()
+		expect(farms.map((farm) => farm.name)).toEqual(['Alpha Farm', 'Zebra Farm'])
+	})
+
+	it('#limit and offset restrict scoped results', async () => {
+		const owner = await Farmer.create({
+			name: 'Limit Owner',
+			email: `limit-owner-${Date.now()}@mail.test`,
+			password: faker.internet.password()
+		}) as Farmer
+		await Farm.create({ farmer_id: owner.id, name: 'Farm A' })
+		await Farm.create({ farmer_id: owner.id, name: 'Farm B' })
+		await Farm.create({ farmer_id: owner.id, name: 'Farm C' })
+
+		const limited = await Farm.where({ farmer_id: owner.id }).orderBy('name', 'asc').limit(2).all()
+		expect(limited.map((farm) => farm.name)).toEqual(['Farm A', 'Farm B'])
+
+		const offset = await Farm.where({ farmer_id: owner.id }).orderBy('name', 'asc').offset(1).limit(1).all()
+		expect(offset.map((farm) => farm.name)).toEqual(['Farm B'])
+	})
+
 	it('#where scope is consumed after first()', async () => {
 		const none = await Farmer.where({ id: 999999 }).first()
 		expect(none).toBe(null)

--- a/test/types/model-types.test.ts
+++ b/test/types/model-types.test.ts
@@ -33,6 +33,12 @@ async function assertDerivedTypes() {
 	if (scoped) {
 		expectTypeOf(scoped).toEqualTypeOf<User>()
 	}
+
+	const ordered = User.orderBy('name', 'desc')
+	expectTypeOf(ordered).toEqualTypeOf<typeof User>()
+
+	const chained = await User.where({ id: userId }).orderBy('name', 'desc').limit(10).all()
+	expectTypeOf(chained).toEqualTypeOf<User[]>()
 }
 
 describe('Model static method return types', () => {


### PR DESCRIPTION
## Summary

Fixes #274. Adds chainable `orderBy`, `limit`, and `offset` static methods to the model query builder so callers can sort and paginate at the database level instead of in application memory.

## Usage

```ts
await Lead.orderBy('created_at', 'desc').all()

await Lead.where({ user_id: userId })
  .orderBy('created_at', 'desc')
  .limit(10)
  .all()
```

## Changes

- Add `ensureCurrentQuery()` helper to initialise the scoped builder when chaining without `where()`
- Add `orderBy(column, direction?)`, `limit(count)`, and `offset(count)` static methods
- Add integration tests for ordering, where + orderBy composition, and limit/offset
- Extend TypeScript type tests for chained return types

## Test plan

- [x] `pnpm test` — 35 tests pass
- [x] `pnpm typecheck`
- [x] `pnpm build`