### PR TITLE
feat: add Model.toArray serialization support

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,6 @@
 import {
 	Model,
+	ModelCollection,
 	HasOneRelation,
 	HasManyRelation,
 	BelongsToRelation,
@@ -21,6 +22,7 @@ import { getTableName, toSnakeCase } from './src/inflect.js'
 
 export {
 	Model,
+	ModelCollection,
 	HasOneRelation,
 	HasManyRelation,
 	BelongsToRelation,

--- a/src/model.ts
+++ b/src/model.ts
@@ -6,6 +6,13 @@ import { createRelationshipMethods } from './relationships.js'
 
 type Row = Record<string, unknown>
 
+class ModelCollection<T extends Model> extends Array<T> {
+	/** Serialises each model in the collection to a plain object. */
+	toArray(): Row[] {
+		return this.map((model) => model.toArray())
+	}
+}
+
 const toError = (error: unknown): Error => {
 	if (error instanceof Error) {
 		return error
@@ -257,12 +264,17 @@ class Model {
 	}
 
 	/** Returns all models for the current scope (or table if unscoped). */
-	static async all<T extends typeof Model>(this: T, columns: string | string[] = '*'): Promise<InstanceType<T>[]> {
+	static async all<T extends typeof Model>(this: T, columns: string | string[] = '*'): Promise<ModelCollection<InstanceType<T>>> {
 		try {
 			const table = this.resolveTable()
 			const query = this.currentQuery ?? getDB()(table)
 			const rows = await query.select<Row[]>(columns as never)
-			return rows.map((row) => new this(row) as InstanceType<T>)
+			const collection = new ModelCollection<InstanceType<T>>()
+			for (const row of rows) {
+				collection.push(new this(row) as InstanceType<T>)
+			}
+
+			return collection
 		} catch (error) {
 			throw toError(error)
 		} finally {
@@ -286,6 +298,28 @@ class Model {
 		} finally {
 			this.currentQuery = undefined
 		}
+	}
+
+	/** Serialises the model to a plain object, excluding internal ORM state and hidden attributes. */
+	toArray(): Row {
+		const data: Row = {}
+		const excluded = new Set([
+			'fillable',
+			'hidden',
+			'modelName',
+			'table',
+			...(Array.isArray(this.hidden) ? this.hidden : []),
+		])
+
+		for (const [key, value] of Object.entries(this)) {
+			if (excluded.has(key) || typeof value === 'function') {
+				continue
+			}
+
+			data[key] = value
+		}
+
+		return data
 	}
 
 	/** Removes internal and hidden fields from a model instance. */
@@ -321,7 +355,7 @@ interface Model {
 
 Object.assign(Model.prototype, createRelationshipMethods(getDB) as Pick<Model, 'hasOne' | 'hasMany' | 'belongsTo'>)
 
-export { Model }
+export { Model, ModelCollection }
 export { HasOneRelation, HasManyRelation, BelongsToRelation, Relation } from './relation.js'
 export {
 	DB,

--- a/test/model.test.ts
+++ b/test/model.test.ts
@@ -433,6 +433,39 @@ describe('#Model tests', () => {
 		expect(await Farmer.find(second.id as number)).not.toBe(null)
 	})
 
+	it('#toArray serialises a model instance without internal or hidden fields', async () => {
+		const farmer = await Farmer.create({
+			name: faker.person.fullName(),
+			email: `to-array-${Date.now()}@mail.test`,
+			password: 'secret-password'
+		}) as Farmer
+
+		const data = farmer.toArray()
+		expect(data).toHaveProperty('id', farmer.id)
+		expect(data).toHaveProperty('name', farmer.name)
+		expect(data).toHaveProperty('email', farmer.email)
+		expect(data).not.toHaveProperty('password')
+		expect(data).not.toHaveProperty('fillable')
+		expect(data).not.toHaveProperty('hidden')
+		expect(data).not.toHaveProperty('modelName')
+		expect(data).not.toHaveProperty('table')
+	})
+
+	it('#toArray serialises model collections returned by all()', async () => {
+		const created = await Farmer.create({
+			name: faker.person.fullName(),
+			email: `collection-${Date.now()}@mail.test`,
+			password: faker.internet.password()
+		})
+		const farmers = await Farmer.where({ id: created.id }).all()
+		const data = farmers.toArray()
+
+		expect(Array.isArray(data)).toBe(true)
+		expect(data.length).toBe(1)
+		expect(data[0]).toHaveProperty('id', created.id)
+		expect(data[0]).not.toHaveProperty('password')
+	})
+
 	it('#all returns models and consumes where scope', async () => {
 		const created = await Farmer.create({
 			name: faker.person.fullName(),

--- a/test/types/model-types.test.ts
+++ b/test/types/model-types.test.ts
@@ -1,5 +1,5 @@
 import { describe, expectTypeOf, it } from 'vitest'
-import { Model } from '../../index.js'
+import { Model, ModelCollection } from '../../index.js'
 
 class User extends Model {
 	override fillable = ['name', 'email', 'password']
@@ -27,7 +27,11 @@ async function assertDerivedTypes() {
 	expectTypeOf(created).toEqualTypeOf<User>()
 
 	const users = await User.all()
-	expectTypeOf(users).toEqualTypeOf<User[]>()
+	expectTypeOf(users).toEqualTypeOf<ModelCollection<User>>()
+	expectTypeOf(users.toArray()).toEqualTypeOf<Record<string, unknown>[]>()
+
+	const serialized = (await User.findOrFail(userId)).toArray()
+	expectTypeOf(serialized).toEqualTypeOf<Record<string, unknown>>()
 
 	const scoped = await User.where({ id: userId }).first()
 	if (scoped) {
@@ -38,7 +42,7 @@ async function assertDerivedTypes() {
 	expectTypeOf(ordered).toEqualTypeOf<typeof User>()
 
 	const chained = await User.where({ id: userId }).orderBy('name', 'desc').limit(10).all()
-	expectTypeOf(chained).toEqualTypeOf<User[]>()
+	expectTypeOf(chained).toEqualTypeOf<ModelCollection<User>>()
 }
 
 describe('Model static method return types', () => {


### PR DESCRIPTION
## Summary

Fixes #272. Adds serialization support so model data can be returned from APIs without leaking internal ORM state.

## Usage

```ts
const user = await User.findOrFail(userId)
return user.toArray()

const users = await User.all()
return users.toArray()
```

## Changes

- Add `toArray()` on model instances — returns a plain object excluding `fillable`, `hidden`, `modelName`, `table`, and any `hidden` attributes
- Add `ModelCollection` (extends `Array`) returned by `all()` with a `toArray()` method for collections
- Export `ModelCollection` from the package entry
- Add integration and TypeScript type tests

## Test plan

- [x] `pnpm test` — 37 tests pass
- [x] `pnpm typecheck`
- [x] `pnpm build`