### PR TITLE
feat: add Model.paginate for paginated query results

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -20,6 +20,8 @@ import {
 } from './src/model.js'
 import { getTableName, toSnakeCase } from './src/inflect.js'
 
+export type { PaginatedResult } from './src/model.js'
+
 export {
 	Model,
 	ModelCollection,

--- a/src/model.ts
+++ b/src/model.ts
@@ -6,6 +6,18 @@ import { createRelationshipMethods } from './relationships.js'
 
 type Row = Record<string, unknown>
 
+interface PaginatedResult<T extends Model> {
+	data: ModelCollection<T>
+	total: number
+	per_page: number
+	current_page: number
+	next_page: number | null
+	prev_page: number | null
+	last_page: number
+}
+
+const DEFAULT_PER_PAGE = 15
+
 class ModelCollection<T extends Model> extends Array<T> {
 	/** Serialises each model in the collection to a plain object. */
 	toArray(): Row[] {
@@ -282,6 +294,44 @@ class Model {
 		}
 	}
 
+	/** Returns a paginated result set for the current scope (or table if unscoped). */
+	static async paginate<T extends typeof Model>(
+		this: T,
+		perPage = DEFAULT_PER_PAGE,
+		page = 1,
+		columns: string | string[] = '*',
+	): Promise<PaginatedResult<InstanceType<T>>> {
+		try {
+			const table = this.resolveTable()
+			const baseQuery = this.currentQuery ?? getDB()(table)
+			const countResult = await baseQuery.clone().count<{ count: string | number }>({ count: '*' }).first()
+			const total = countResult ? Number(countResult.count) : 0
+			const lastPage = Math.max(1, Math.ceil(total / perPage) || 1)
+			const currentPage = Math.min(Math.max(1, page), lastPage)
+			const offset = (currentPage - 1) * perPage
+			const rows = await baseQuery.clone().select<Row[]>(columns as never).limit(perPage).offset(offset)
+			const collection = new ModelCollection<InstanceType<T>>()
+
+			for (const row of rows) {
+				collection.push(new this(row) as InstanceType<T>)
+			}
+
+			return {
+				data: collection,
+				total,
+				per_page: perPage,
+				current_page: currentPage,
+				next_page: currentPage < lastPage ? currentPage + 1 : null,
+				prev_page: currentPage > 1 ? currentPage - 1 : null,
+				last_page: lastPage,
+			}
+		} catch (error) {
+			throw toError(error)
+		} finally {
+			this.currentQuery = undefined
+		}
+	}
+
 	/** Returns a row count for the current scope (or table if unscoped). */
 	static async count(this: typeof Model, column = '*'): Promise<number> {
 		try {
@@ -356,6 +406,7 @@ interface Model {
 Object.assign(Model.prototype, createRelationshipMethods(getDB) as Pick<Model, 'hasOne' | 'hasMany' | 'belongsTo'>)
 
 export { Model, ModelCollection }
+export type { PaginatedResult }
 export { HasOneRelation, HasManyRelation, BelongsToRelation, Relation } from './relation.js'
 export {
 	DB,

--- a/test/model.test.ts
+++ b/test/model.test.ts
@@ -433,6 +433,54 @@ describe('#Model tests', () => {
 		expect(await Farmer.find(second.id as number)).not.toBe(null)
 	})
 
+	it('#paginate returns paginated data and metadata', async () => {
+		const owner = await Farmer.create({
+			name: 'Paginate Owner',
+			email: `paginate-owner-${Date.now()}@mail.test`,
+			password: faker.internet.password()
+		}) as Farmer
+		await Farm.create({ farmer_id: owner.id, name: 'Farm 1' })
+		await Farm.create({ farmer_id: owner.id, name: 'Farm 2' })
+		await Farm.create({ farmer_id: owner.id, name: 'Farm 3' })
+
+		const pageOne = await Farm.where({ farmer_id: owner.id }).orderBy('name', 'asc').paginate(2, 1)
+		expect(pageOne.data).toHaveLength(2)
+		expect(pageOne.total).toBe(3)
+		expect(pageOne.per_page).toBe(2)
+		expect(pageOne.current_page).toBe(1)
+		expect(pageOne.last_page).toBe(2)
+		expect(pageOne.next_page).toBe(2)
+		expect(pageOne.prev_page).toBe(null)
+		expect(pageOne.data[0]).toHaveProperty('name', 'Farm 1')
+
+		const pageTwo = await Farm.where({ farmer_id: owner.id }).orderBy('name', 'asc').paginate(2, 2)
+		expect(pageTwo.data).toHaveLength(1)
+		expect(pageTwo.current_page).toBe(2)
+		expect(pageTwo.next_page).toBe(null)
+		expect(pageTwo.prev_page).toBe(1)
+		expect(pageTwo.data[0]).toHaveProperty('name', 'Farm 3')
+	})
+
+	it('#paginate defaults to 15 items per page and page 1', async () => {
+		const result = await Farmer.paginate()
+		expect(result.per_page).toBe(15)
+		expect(result.current_page).toBe(1)
+		expect(result.data.length).toBeLessThanOrEqual(15)
+		expect(result.total).toBeGreaterThan(0)
+	})
+
+	it('#paginate consumes where scope after execution', async () => {
+		const created = await Farmer.create({
+			name: faker.person.fullName(),
+			email: `paginate-scope-${Date.now()}@mail.test`,
+			password: faker.internet.password()
+		})
+
+		await Farmer.where({ id: created.id }).paginate(10)
+		const unscoped = await Farmer.first()
+		expect(unscoped).not.toBe(null)
+	})
+
 	it('#toArray serialises a model instance without internal or hidden fields', async () => {
 		const farmer = await Farmer.create({
 			name: faker.person.fullName(),

--- a/test/types/model-types.test.ts
+++ b/test/types/model-types.test.ts
@@ -1,5 +1,5 @@
 import { describe, expectTypeOf, it } from 'vitest'
-import { Model, ModelCollection } from '../../index.js'
+import { Model, ModelCollection, type PaginatedResult } from '../../index.js'
 
 class User extends Model {
 	override fillable = ['name', 'email', 'password']
@@ -43,6 +43,10 @@ async function assertDerivedTypes() {
 
 	const chained = await User.where({ id: userId }).orderBy('name', 'desc').limit(10).all()
 	expectTypeOf(chained).toEqualTypeOf<ModelCollection<User>>()
+
+	const paginated = await User.paginate(10, 1)
+	expectTypeOf(paginated).toEqualTypeOf<PaginatedResult<User>>()
+	expectTypeOf(paginated.data).toEqualTypeOf<ModelCollection<User>>()
 }
 
 describe('Model static method return types', () => {


### PR DESCRIPTION
## Summary

Fixes #271. Adds built-in pagination to the static query builder so callers no longer need to manually chain `limit`, `offset`, and `count`.

## Usage

```ts
// Defaults: 15 per page, page 1
const posts = await Post.paginate()

// Custom page size
const posts = await Post.paginate(10)

// Page number + scoped query
const leads = await Lead.where({ user_id: userId })
  .orderBy('created_at', 'desc')
  .paginate(10, 2)
```

## Return shape

```ts
{
  data: ModelCollection<Post>,
  total: number,
  per_page: number,
  current_page: number,
  next_page: number | null,
  prev_page: number | null,
  last_page: number,
}
```

## Changes

- Add `Model.paginate(perPage?, page?, columns?)` terminal method
- Export `PaginatedResult` type from the package entry
- Compose with existing `where` / `orderBy` scopes; reset scope after execution
- Add integration and TypeScript type tests

## Test plan

- [x] `pnpm test` — 40 tests pass
- [x] `pnpm typecheck`
- [x] `pnpm build`