### PR TITLE
docs: add JSDoc comments across the public API

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,13 @@
+/**
+ * Mevn ORM — a small ActiveRecord-style ORM built on Knex.
+ *
+ * Configure the database once at startup, extend {@link Model} for your tables,
+ * then use static query methods, instance persistence, relationships, and
+ * migration helpers.
+ *
+ * @packageDocumentation
+ */
+
 import {
 	Model,
 	ModelCollection,

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,6 +15,7 @@ const toError = (error: unknown): Error => {
 	return new Error(String(error))
 }
 
+/** Active Knex instance. Available after calling {@link configure} or {@link configureDatabase}. */
 let DB: Knex | undefined
 let defaultMigrationConfig: Knex.MigratorConfig = {}
 
@@ -55,7 +56,12 @@ interface MigrationResult {
 	log: string[]
 }
 
-/** Returns the active Knex instance or throws if the ORM has not been configured. */
+/**
+ * Returns the active Knex instance.
+ *
+ * @returns Configured Knex client.
+ * @throws When {@link configure} or {@link configureDatabase} has not been called.
+ */
 const getDB = (): Knex => {
 	if (!DB) {
 		throw new Error('Mevn ORM is not configured. Call configure({ client, connection, ... }) before using Model.')
@@ -64,7 +70,12 @@ const getDB = (): Knex => {
 	return DB
 }
 
-/** Configures the ORM using a Knex config object or an existing Knex instance. */
+/**
+ * Initialises the ORM with a raw Knex config object or an existing Knex instance.
+ *
+ * @param config - Knex configuration or a pre-built Knex instance.
+ * @returns The active Knex client (also available as {@link DB}).
+ */
 const configure = (config: Knex.Config | Knex): Knex => {
 	if (typeof config === 'function') {
 		DB = config
@@ -75,13 +86,28 @@ const configure = (config: Knex.Config | Knex): Knex => {
 	return DB
 }
 
-/** Sets default migration options used by migration helpers. */
+/**
+ * Sets default migration options used by {@link makeMigration}, {@link migrateLatest},
+ * and other migration helpers.
+ *
+ * @param config - Knex migrator config (typically `directory` and `extension`).
+ * @returns A copy of the stored migration config.
+ *
+ * @example
+ * ```ts
+ * setMigrationConfig({ directory: './migrations', extension: 'ts' })
+ * ```
+ */
 const setMigrationConfig = (config: Knex.MigratorConfig): Knex.MigratorConfig => {
 	defaultMigrationConfig = { ...config }
 	return { ...defaultMigrationConfig }
 }
 
-/** Returns the currently configured default migration options. */
+/**
+ * Returns the currently configured default migration options.
+ *
+ * @returns Copy of the migration config set via {@link setMigrationConfig}.
+ */
 const getMigrationConfig = (): Knex.MigratorConfig => ({ ...defaultMigrationConfig })
 
 const resolveMigrationConfig = (config?: Knex.MigratorConfig): Knex.MigratorConfig => ({
@@ -181,7 +207,15 @@ const buildConnection = (config: SimpleDatabaseConfig): NonNullable<Knex.Config[
 	return connection
 }
 
-/** Builds a Knex config from simple database options using documented `client`/`connection` keys. */
+/**
+ * Builds a Knex config from simple database options.
+ *
+ * Prefer `client` over the deprecated `dialect` field. Connection details can be
+ * supplied as a `connection` object/string or as top-level `host`/`filename` fields.
+ *
+ * @param config - Simplified database configuration.
+ * @returns Knex config ready for {@link configure}.
+ */
 const createKnexConfig = (config: SimpleDatabaseConfig): Knex.Config => {
 	const client = normalizeClient(getConfiguredClient(config))
 	const base: Knex.Config = {
@@ -202,10 +236,31 @@ const createKnexConfig = (config: SimpleDatabaseConfig): Knex.Config => {
 	return base
 }
 
-/** Configures the ORM from simple database options. */
+/**
+ * Initialises the ORM from simple database options.
+ *
+ * This is the recommended entry point for most applications.
+ *
+ * @param config - Simplified database configuration with `client` and connection fields.
+ * @returns The active Knex client (also available as {@link DB}).
+ *
+ * @example
+ * ```ts
+ * configureDatabase({
+ *   client: 'sqlite3',
+ *   connection: { filename: './dev.sqlite' }
+ * })
+ * ```
+ */
 const configureDatabase = (config: SimpleDatabaseConfig): Knex => configure(createKnexConfig(config))
 
-/** Generates a migration file and returns its path. */
+/**
+ * Generates a Knex migration file and returns its absolute path.
+ *
+ * @param name - Migration name (e.g. `create_users_table`).
+ * @param config - Optional per-call migrator overrides.
+ * @returns Path to the created migration file.
+ */
 const makeMigration = async (name: string, config?: Knex.MigratorConfig): Promise<string> => {
 	try {
 		return await getDB().migrate.make(name, resolveMigrationConfig(config))
@@ -214,7 +269,12 @@ const makeMigration = async (name: string, config?: Knex.MigratorConfig): Promis
 	}
 }
 
-/** Runs pending migrations and returns the batch number and migration filenames. */
+/**
+ * Runs all pending migrations.
+ *
+ * @param config - Optional per-call migrator overrides.
+ * @returns Batch number and filenames of migrations executed in this run.
+ */
 const migrateLatest = async (config?: Knex.MigratorConfig): Promise<MigrationResult> => {
 	try {
 		const [batch, log] = await getDB().migrate.latest(resolveMigrationConfig(config))
@@ -224,7 +284,13 @@ const migrateLatest = async (config?: Knex.MigratorConfig): Promise<MigrationRes
 	}
 }
 
-/** Rolls back migrations. Set `all` to true to rollback all completed batches. */
+/**
+ * Rolls back the most recent migration batch.
+ *
+ * @param config - Optional per-call migrator overrides.
+ * @param all - When `true`, rolls back all completed batches.
+ * @returns Batch number and filenames of migrations rolled back.
+ */
 const migrateRollback = async (config?: Knex.MigratorConfig, all = false): Promise<MigrationResult> => {
 	try {
 		const [batch, log] = all
@@ -236,7 +302,12 @@ const migrateRollback = async (config?: Knex.MigratorConfig, all = false): Promi
 	}
 }
 
-/** Returns the current migration version recorded by Knex. */
+/**
+ * Returns the current migration version recorded by Knex.
+ *
+ * @param config - Optional per-call migrator overrides.
+ * @returns Latest applied migration name, or `'none'` when no migrations have run.
+ */
 const migrateCurrentVersion = async (config?: Knex.MigratorConfig): Promise<string> => {
 	try {
 		return await getDB().migrate.currentVersion(resolveMigrationConfig(config))
@@ -245,7 +316,12 @@ const migrateCurrentVersion = async (config?: Knex.MigratorConfig): Promise<stri
 	}
 }
 
-/** Returns completed and pending migration filenames. */
+/**
+ * Lists completed and pending migration filenames.
+ *
+ * @param config - Optional per-call migrator overrides.
+ * @returns Object with `completed` and `pending` migration filename arrays.
+ */
 const migrateList = async (config?: Knex.MigratorConfig): Promise<{ completed: string[]; pending: string[] }> => {
 	try {
 		const [completed, pending] = await getDB().migrate.list(resolveMigrationConfig(config))

--- a/src/inflect.ts
+++ b/src/inflect.ts
@@ -1,13 +1,35 @@
 import pluralize from 'pluralize'
 
-/** Converts PascalCase/camelCase identifiers to snake_case. */
+/**
+ * Converts a PascalCase or camelCase identifier to snake_case.
+ *
+ * @param value - Class or property name (e.g. `PasswordResetToken`).
+ * @returns Snake_case equivalent (e.g. `password_reset_token`).
+ *
+ * @example
+ * ```ts
+ * toSnakeCase('PasswordResetToken') // 'password_reset_token'
+ * toSnakeCase('User')               // 'user'
+ * ```
+ */
 const toSnakeCase = (value: string): string =>
 	value
 		.replace(/([a-z])([A-Z])/g, '$1_$2')
 		.replace(/([A-Z])([A-Z][a-z])/g, '$1_$2')
 		.toLowerCase()
 
-/** Resolves the pluralized snake_case table name for a model class name. */
+/**
+ * Resolves the pluralised snake_case table name for a model class name.
+ *
+ * @param className - Model class name (e.g. `User`, `PasswordResetToken`).
+ * @returns Pluralised table name (e.g. `users`, `password_reset_tokens`).
+ *
+ * @example
+ * ```ts
+ * getTableName('User')               // 'users'
+ * getTableName('PasswordResetToken') // 'password_reset_tokens'
+ * ```
+ */
 const getTableName = (className: string): string => pluralize(toSnakeCase(className))
 
 export { toSnakeCase, getTableName }

--- a/src/model.ts
+++ b/src/model.ts
@@ -6,20 +6,44 @@ import { createRelationshipMethods } from './relationships.js'
 
 type Row = Record<string, unknown>
 
+/**
+ * Paginated query result returned by {@link Model.paginate}.
+ *
+ * @typeParam T - Model instance type contained in `data`.
+ */
 interface PaginatedResult<T extends Model> {
+	/** Model instances for the current page. */
 	data: ModelCollection<T>
+	/** Total rows matching the scoped query across all pages. */
 	total: number
+	/** Requested page size. */
 	per_page: number
+	/** Current page number (1-based). */
 	current_page: number
+	/** Next page number, or `null` on the last page. */
 	next_page: number | null
+	/** Previous page number, or `null` on the first page. */
 	prev_page: number | null
+	/** Total number of pages. */
 	last_page: number
 }
 
 const DEFAULT_PER_PAGE = 15
 
+/**
+ * Array subclass returned by {@link Model.all} and {@link Model.paginate}.
+ *
+ * Extends `Array` so it remains compatible with array operations while adding
+ * {@link ModelCollection.toArray | toArray()} for API serialisation.
+ *
+ * @typeParam T - Model instance type stored in the collection.
+ */
 class ModelCollection<T extends Model> extends Array<T> {
-	/** Serialises each model in the collection to a plain object. */
+	/**
+	 * Serialises every model in the collection to a plain object.
+	 *
+	 * @returns Array of serialised records (respects each model's `hidden` fields).
+	 */
 	toArray(): Row[] {
 		return this.map((model) => model.toArray())
 	}
@@ -33,24 +57,62 @@ const toError = (error: unknown): Error => {
 	return new Error(String(error))
 }
 
+/**
+ * ActiveRecord-style base model backed by Knex.
+ *
+ * Extend this class for each database table. Table names are inferred from the
+ * class name unless overridden via `override table`. Use static methods for
+ * queries and instance methods for row-level persistence.
+ *
+ * @example
+ * ```ts
+ * class User extends Model {
+ *   override fillable = ['name', 'email', 'password']
+ *   override hidden = ['password']
+ * }
+ *
+ * const user = await User.create({ name: 'Jane', email: 'jane@example.com' })
+ * const page = await User.orderBy('name').paginate(10)
+ * ```
+ */
 class Model {
 	[key: string]: any
 
 	#private: string[]
 
+	/**
+	 * Resolved database table name for this model class.
+	 *
+	 * Honours subclass `override table` declarations.
+	 */
 	static get currentTable(): string {
 		return this.resolveTable()
 	}
 
-	// `where()` stores a static scoped query consumed by `first()`.
+	/**
+	 * Active scoped Knex query built by `where()`, `orderBy()`, and other chain methods.
+	 *
+	 * Consumed and reset by terminal methods such as `first()`, `all()`, and `paginate()`.
+	 */
 	static currentQuery: Knex.QueryBuilder<Row, Row[]> | undefined
 
-	/** Resolves the table name for this model, honouring subclass `table` overrides. */
+	/**
+	 * Resolves the database table name for this model class.
+	 *
+	 * Instantiates the subclass to read its `table` property, so explicit
+	 * `override table` values are honoured on static query paths.
+	 *
+	 * @returns Resolved table name.
+	 */
 	static resolveTable(this: typeof Model): string {
 		return new this().table
 	}
 
-	/** Returns the active scoped query, initialising one against the model table when absent. */
+	/**
+	 * Returns the active scoped query, initialising one against the model table when absent.
+	 *
+	 * Used internally by chain methods like `orderBy()` when called without a prior `where()`.
+	 */
 	static ensureCurrentQuery(this: typeof Model): Knex.QueryBuilder<Row, Row[]> {
 		if (!this.currentQuery) {
 			const table = this.resolveTable()
@@ -60,12 +122,26 @@ class Model {
 		return this.currentQuery
 	}
 
+	/** Attributes allowed through {@link Model.save | save()} mass assignment. */
 	fillable: string[]
+
+	/** Attributes excluded from {@link Model.toArray | toArray()} and stripped after reads. */
 	hidden: string[]
+
+	/** Snake_case singular name derived from the class name (used for default foreign keys). */
 	modelName: string
+
+	/** Database table this model maps to. Override when inference does not match your schema. */
 	table: string
+
+	/** Primary key value, set after insert or load. */
 	id?: number
 
+	/**
+	 * Creates a model instance from a database row or plain object.
+	 *
+	 * @param properties - Initial attribute values.
+	 */
 	constructor(properties: Row = {}) {
 		Object.assign(this, properties)
 		this.fillable = []
@@ -75,7 +151,11 @@ class Model {
 		this.table = getTableName(this.constructor.name)
 	}
 
-	/** Inserts the current model using `fillable` attributes and reloads it from the database. */
+	/**
+	 * Inserts the current model using {@link Model.fillable | fillable} attributes and reloads it.
+	 *
+	 * @returns This instance with database-assigned fields (including `id`) populated.
+	 */
 	async save(): Promise<this> {
 		try {
 			const rows: Row = {}
@@ -100,7 +180,13 @@ class Model {
 		}
 	}
 
-	/** Updates the current row by primary key and returns a refreshed model instance. */
+	/**
+	 * Updates the current row by primary key and returns a refreshed model instance.
+	 *
+	 * @param properties - Columns and values to update.
+	 * @returns Refreshed instance with updated attributes.
+	 * @throws When the instance has no `id`.
+	 */
 	async update(properties: Row): Promise<this> {
 		if (this.id === undefined) {
 			throw new Error('Cannot update model without id')
@@ -121,7 +207,11 @@ class Model {
 		}
 	}
 
-	/** Deletes the current row by primary key. */
+	/**
+	 * Deletes the current row by primary key.
+	 *
+	 * @throws When the instance has no `id`.
+	 */
 	async delete(): Promise<void> {
 		if (this.id === undefined) {
 			throw new Error('Cannot delete model without id')
@@ -134,7 +224,15 @@ class Model {
 		}
 	}
 
-	/** Updates rows in the model table, optionally scoped by `where()`. */
+	/**
+	 * Bulk-updates rows in the model table.
+	 *
+	 * When preceded by {@link Model.where | where()}, only scoped rows are updated.
+	 * The query scope is reset after execution.
+	 *
+	 * @param properties - Columns and values to update.
+	 * @returns Number of rows updated.
+	 */
 	static async update(properties: Row): Promise<number | undefined> {
 		try {
 			const table = this.resolveTable()
@@ -147,7 +245,14 @@ class Model {
 		}
 	}
 
-	/** Deletes rows in the model table, optionally scoped by `where()`. */
+	/**
+	 * Bulk-deletes rows in the model table.
+	 *
+	 * When preceded by {@link Model.where | where()}, only scoped rows are deleted.
+	 * The query scope is reset after execution.
+	 *
+	 * @returns Number of rows deleted.
+	 */
 	static async destroy(): Promise<number | undefined> {
 		try {
 			const table = this.resolveTable()
@@ -160,7 +265,13 @@ class Model {
 		}
 	}
 
-	/** Finds a single model by primary key. */
+	/**
+	 * Finds a single model by primary key.
+	 *
+	 * @param id - Primary key value.
+	 * @param columns - Columns to select (default `'*'`).
+	 * @returns Model instance, or `null` when not found. Preserves the derived class type.
+	 */
 	static async find<T extends typeof Model>(this: T, id: number | string, columns: string | string[] = '*'): Promise<InstanceType<T> | null> {
 		const table = this.resolveTable()
 
@@ -172,7 +283,14 @@ class Model {
 		}
 	}
 
-	/** Finds a model by primary key or throws if it does not exist. */
+	/**
+	 * Finds a model by primary key or throws when it does not exist.
+	 *
+	 * @param id - Primary key value.
+	 * @param columns - Columns to select (default `'*'`).
+	 * @returns Model instance. Preserves the derived class type.
+	 * @throws When no row matches the given id.
+	 */
 	static async findOrFail<T extends typeof Model>(this: T, id: number | string, columns: string | string[] = '*'): Promise<InstanceType<T>> {
 		const found = await this.find(id, columns)
 		if (!found) {
@@ -182,7 +300,12 @@ class Model {
 		return found
 	}
 
-	/** Creates and returns a single model record. */
+	/**
+	 * Inserts a row and returns the created model instance.
+	 *
+	 * @param properties - Column values to insert.
+	 * @returns Created model with `hidden` fields stripped. Preserves the derived class type.
+	 */
 	static async create<T extends typeof Model>(this: T, properties: Row): Promise<InstanceType<T>> {
 		const table = this.resolveTable()
 
@@ -203,7 +326,12 @@ class Model {
 		}
 	}
 
-	/** Creates multiple model records and returns created model instances. */
+	/**
+	 * Inserts multiple rows sequentially and returns created model instances.
+	 *
+	 * @param properties - Array of column value objects to insert.
+	 * @returns Created model instances in insertion order.
+	 */
 	static async createMany<T extends typeof Model>(this: T, properties: Row[]): Promise<InstanceType<T>[]> {
 		if (properties.length === 0) {
 			return []
@@ -220,7 +348,13 @@ class Model {
 		}
 	}
 
-	/** Returns the first matching row or creates it with merged values when missing. */
+	/**
+	 * Returns the first row matching `attributes`, or creates one with merged values.
+	 *
+	 * @param attributes - Lookup conditions.
+	 * @param values - Additional values used only when creating a new row.
+	 * @returns Existing or newly created model instance.
+	 */
 	static async firstOrCreate<T extends typeof Model>(this: T, attributes: Row, values: Row = {}): Promise<InstanceType<T>> {
 		const table = this.resolveTable()
 		try {
@@ -236,32 +370,64 @@ class Model {
 		}
 	}
 
-	/** Applies a query scope used by chained static query methods. */
+	/**
+	 * Starts a scoped query with a `where` clause.
+	 *
+	 * Chain further constraints (`orderBy`, `limit`, …) then call a terminal method
+	 * (`first`, `all`, `paginate`, `count`, `update`, `destroy`).
+	 *
+	 * @param conditions - Equality conditions passed to Knex `where`.
+	 * @returns Model constructor for chaining.
+	 */
 	static where<T extends typeof Model>(this: T, conditions: Row = {}): T {
 		const table = this.resolveTable()
 		this.currentQuery = getDB()(table).where(conditions) as Knex.QueryBuilder<Row, Row[]>
 		return this
 	}
 
-	/** Appends an `orderBy` clause to the current scoped query. */
+	/**
+	 * Appends an `orderBy` clause to the current scoped query.
+	 *
+	 * @param column - Column to sort by.
+	 * @param direction - Sort direction (`'asc'` or `'desc'`). Defaults to `'asc'`.
+	 * @returns Model constructor for chaining.
+	 */
 	static orderBy<T extends typeof Model>(this: T, column: string, direction: 'asc' | 'desc' = 'asc'): T {
 		this.ensureCurrentQuery().orderBy(column, direction)
 		return this
 	}
 
-	/** Appends a `limit` clause to the current scoped query. */
+	/**
+	 * Appends a `limit` clause to the current scoped query.
+	 *
+	 * @param count - Maximum number of rows to return.
+	 * @returns Model constructor for chaining.
+	 */
 	static limit<T extends typeof Model>(this: T, count: number): T {
 		this.ensureCurrentQuery().limit(count)
 		return this
 	}
 
-	/** Appends an `offset` clause to the current scoped query. */
+	/**
+	 * Appends an `offset` clause to the current scoped query.
+	 *
+	 * @param count - Number of rows to skip (commonly paired with {@link Model.limit | limit()}).
+	 * @returns Model constructor for chaining.
+	 */
 	static offset<T extends typeof Model>(this: T, count: number): T {
 		this.ensureCurrentQuery().offset(count)
 		return this
 	}
 
-	/** Returns the first model for the current scope (or table if unscoped). */
+	/**
+	 * Returns the first model matching the current scope.
+	 *
+	 * When no scope is active, returns the first row in the table.
+	 * The query scope is reset after execution.
+	 *
+	 * @param columns - Columns to select (default `'*'`).
+	 * @returns First matching model, or `null` when none found.
+	 */
 	static async first<T extends typeof Model>(this: T, columns: string | string[] = '*'): Promise<InstanceType<T> | null> {
 		try {
 			const table = this.resolveTable()
@@ -275,7 +441,15 @@ class Model {
 		}
 	}
 
-	/** Returns all models for the current scope (or table if unscoped). */
+	/**
+	 * Returns all models matching the current scope.
+	 *
+	 * When no scope is active, returns every row in the table.
+	 * The query scope is reset after execution.
+	 *
+	 * @param columns - Columns to select (default `'*'`).
+	 * @returns {@link ModelCollection} of matching models.
+	 */
 	static async all<T extends typeof Model>(this: T, columns: string | string[] = '*'): Promise<ModelCollection<InstanceType<T>>> {
 		try {
 			const table = this.resolveTable()
@@ -294,7 +468,22 @@ class Model {
 		}
 	}
 
-	/** Returns a paginated result set for the current scope (or table if unscoped). */
+	/**
+	 * Returns a paginated result set for the current scope.
+	 *
+	 * Runs a count query and a data query against the scoped builder.
+	 * The query scope is reset after execution.
+	 *
+	 * @param perPage - Items per page (default `15`).
+	 * @param page - Page number, 1-based (default `1`).
+	 * @param columns - Columns to select (default `'*'`).
+	 * @returns Paginated data and metadata.
+	 *
+	 * @example
+	 * ```ts
+	 * const result = await Post.where({ published: true }).orderBy('created_at', 'desc').paginate(10, 2)
+	 * ```
+	 */
 	static async paginate<T extends typeof Model>(
 		this: T,
 		perPage = DEFAULT_PER_PAGE,
@@ -332,7 +521,15 @@ class Model {
 		}
 	}
 
-	/** Returns a row count for the current scope (or table if unscoped). */
+	/**
+	 * Returns a row count for the current scope.
+	 *
+	 * When no scope is active, counts all rows in the table.
+	 * The query scope is reset after execution.
+	 *
+	 * @param column - Column to count (default `'*'` for all rows).
+	 * @returns Matching row count.
+	 */
 	static async count(this: typeof Model, column = '*'): Promise<number> {
 		try {
 			const table = this.resolveTable()
@@ -350,7 +547,14 @@ class Model {
 		}
 	}
 
-	/** Serialises the model to a plain object, excluding internal ORM state and hidden attributes. */
+	/**
+	 * Serialises the model to a plain object for API responses.
+	 *
+	 * Excludes ORM internals (`fillable`, `hidden`, `modelName`, `table`) and
+	 * any attributes listed in {@link Model.hidden | hidden}.
+	 *
+	 * @returns Plain data object safe to return from HTTP handlers.
+	 */
 	toArray(): Row {
 		const data: Row = {}
 		const excluded = new Set([
@@ -372,9 +576,14 @@ class Model {
 		return data
 	}
 
-	/** Removes internal and hidden fields from a model instance. */
+	/**
+	 * Removes internal and hidden fields from a model instance in place.
+	 *
+	 * @param model - Model object to strip.
+	 * @param keepInternalState - When `true`, retains `fillable` and `hidden` keys.
+	 * @returns The same object reference with keys removed.
+	 */
 	stripColumns<T extends Record<string, unknown>>(model: T, keepInternalState = false): T {
-		// Hide internal ORM fields and caller-defined hidden attributes.
 		const privateKeys = keepInternalState ? [] : this.#private
 		const hiddenKeys = Array.isArray(this.hidden) ? this.hidden : []
 		for (const key of [...privateKeys, ...hiddenKeys]) {
@@ -386,16 +595,59 @@ class Model {
 }
 
 interface Model {
+	/**
+	 * Defines a one-to-one relationship to another model.
+	 *
+	 * @param Related - Related model class constructor.
+	 * @param localKey - Parent key value (defaults to `this.id`).
+	 * @param foreignKey - Foreign key column on the related table (defaults to `{modelName}_id`).
+	 * @returns Lazy {@link HasOneRelation} — await directly or chain `where()` before executing.
+	 *
+	 * @example
+	 * ```ts
+	 * const profile = await user.profile()
+	 * const active = await user.profile().where({ active: true }).first()
+	 * ```
+	 */
 	hasOne<T extends typeof Model>(
 		Related: T,
 		localKey?: number | string,
 		foreignKey?: string,
 	): HasOneRelation<InstanceType<T>>
+
+	/**
+	 * Defines a one-to-many relationship to another model.
+	 *
+	 * @param Related - Related model class constructor.
+	 * @param localKey - Parent key value (defaults to `this.id`).
+	 * @param foreignKey - Foreign key column on the related table (defaults to `{modelName}_id`).
+	 * @returns Lazy {@link HasManyRelation} — await for all rows or call `.get()` / `.first()`.
+	 *
+	 * @example
+	 * ```ts
+	 * const posts = await user.posts()
+	 * const drafts = await user.posts().where({ status: 'draft' }).get()
+	 * ```
+	 */
 	hasMany<T extends typeof Model>(
 		Related: T,
 		localKey?: number | string,
 		foreignKey?: string,
 	): HasManyRelation<InstanceType<T>>
+
+	/**
+	 * Defines an inverse belongs-to relationship to a parent model.
+	 *
+	 * @param Related - Parent model class constructor.
+	 * @param foreignKey - Foreign key column on this model (defaults to `{relatedModelName}_id`).
+	 * @param ownerKey - Primary key column on the parent table (defaults to `'id'`).
+	 * @returns Lazy {@link BelongsToRelation} — await directly or chain `where()` before executing.
+	 *
+	 * @example
+	 * ```ts
+	 * const author = await post.author()
+	 * ```
+	 */
 	belongsTo<T extends typeof Model>(
 		Related: T,
 		foreignKey?: string,

--- a/src/relation.ts
+++ b/src/relation.ts
@@ -11,7 +11,13 @@ interface RelationshipModel {
 
 type RelatedModelCtor<T extends RelationshipModel = RelationshipModel> = new (properties?: Row) => T
 
-/** Base relation wrapper that builds a lazy Knex query against a related model. */
+/**
+ * Lazy relation query wrapper backed by Knex.
+ *
+ * Relation instances are {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise | Promise-like}:
+ * `await farmer.profile()` auto-executes the query. Chain `where()` before awaiting
+ * to refine the query, or call `first()` / `get()` explicitly.
+ */
 abstract class Relation<TResult, TRelated extends RelationshipModel = RelationshipModel> implements PromiseLike<TResult> {
 	protected readonly Related: RelatedModelCtor<TRelated>
 	protected readonly query: Knex.QueryBuilder<Row, Row[]> | null
@@ -21,13 +27,23 @@ abstract class Relation<TResult, TRelated extends RelationshipModel = Relationsh
 		this.query = query
 	}
 
-	/** Appends a `where` constraint to the underlying query builder. */
+	/**
+	 * Appends a `where` constraint to the underlying Knex query.
+	 *
+	 * @param args - Knex `where` arguments (object or column/value pairs).
+	 * @returns This relation instance for chaining.
+	 */
 	where(...args: unknown[]): this {
 		this.query?.where(...(args as [never, ...never[]]))
 		return this
 	}
 
-	/** Executes the relation query and returns the first matching related model. */
+	/**
+	 * Executes the relation query and returns the first matching related model.
+	 *
+	 * @param columns - Columns to select (default `'*'`).
+	 * @returns Related model instance, or `null` when no row matches.
+	 */
 	async first(columns: string | string[] = '*'): Promise<TRelated | null> {
 		if (!this.query) {
 			return null
@@ -42,7 +58,12 @@ abstract class Relation<TResult, TRelated extends RelationshipModel = Relationsh
 		return related.stripColumns(related)
 	}
 
-	/** Executes the relation query and returns all matching related models. */
+	/**
+	 * Executes the relation query and returns all matching related models.
+	 *
+	 * @param columns - Columns to select (default `'*'`).
+	 * @returns Array of related model instances (empty when no rows match).
+	 */
 	async get(columns: string | string[] = '*'): Promise<TRelated[]> {
 		if (!this.query) {
 			return []
@@ -55,6 +76,12 @@ abstract class Relation<TResult, TRelated extends RelationshipModel = Relationsh
 		})
 	}
 
+	/**
+	 * Allows `await relation` without calling `first()` or `get()` explicitly.
+	 *
+	 * @param onFulfilled - Success callback.
+	 * @param onRejected - Error callback.
+	 */
 	then<TResult1 = TResult, TResult2 = never>(
 		onFulfilled?: ((value: TResult) => TResult1 | PromiseLike<TResult1>) | null,
 		onRejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null,
@@ -65,18 +92,33 @@ abstract class Relation<TResult, TRelated extends RelationshipModel = Relationsh
 	protected abstract resolve(): Promise<TResult>
 }
 
+/**
+ * One-to-one relation. Awaiting resolves to a single related model or `null`.
+ *
+ * @typeParam T - Related model instance type.
+ */
 class HasOneRelation<T extends RelationshipModel = RelationshipModel> extends Relation<T | null, T> {
 	protected resolve(): Promise<T | null> {
 		return this.first()
 	}
 }
 
+/**
+ * One-to-many relation. Awaiting resolves to an array of related models.
+ *
+ * @typeParam T - Related model instance type.
+ */
 class HasManyRelation<T extends RelationshipModel = RelationshipModel> extends Relation<T[], T> {
 	protected resolve(): Promise<T[]> {
 		return this.get()
 	}
 }
 
+/**
+ * Inverse belongs-to relation. Awaiting resolves to the parent model or `null`.
+ *
+ * @typeParam T - Related model instance type.
+ */
 class BelongsToRelation<T extends RelationshipModel = RelationshipModel> extends Relation<T | null, T> {
 	protected resolve(): Promise<T | null> {
 		return this.first()


### PR DESCRIPTION
## Summary

Adds JSDoc comments across the library's public API so IDE hovers, IntelliSense, and published `.d.ts` files show meaningful descriptions — not just bare signatures.

## What's documented

- **Package entry** (`index.ts`) — `@packageDocumentation` module overview
- **`Model`** — class overview, properties (`fillable`, `hidden`, `table`, …), all static and instance methods
- **`ModelCollection`** / **`PaginatedResult`** — class, interface, and field docs
- **Relationships** — `hasOne`, `hasMany`, `belongsTo` on the `Model` interface; `Relation` subclasses
- **Config helpers** — `configureDatabase`, `configure`, `getDB`, migration APIs with `@param` / `@returns` / `@example`
- **Inflection** — `getTableName`, `toSnakeCase` with usage examples

Comments are emitted into `dist/*.d.ts` on build, so consumers get docs from the published package.

## Test plan

- [x] `pnpm test` — 40 tests pass
- [x] `pnpm typecheck`
- [x] `pnpm build` — JSDoc present in generated declarations