### PR TITLE
docs: add VitePress documentation site

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,6 @@ SECURITY.md export-ignore
 test export-ignore
 test.sh export-ignore
 initDb export-ignore
+
+# Exclude VitePress docs from GitHub language stats
+docs/** linguist-documentation

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,59 @@
+# Build and deploy the VitePress docs site to GitHub Pages.
+# Repo settings → Pages → Source: GitHub Actions
+
+name: Deploy docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # lastUpdated in VitePress needs full history
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 25.x
+
+      - uses: pnpm/action-setup@v6
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build VitePress
+        run: pnpm run docs:build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/.vitepress/dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ local_test
 *.sqlite
 dist
 .DS_Store
+docs/.vitepress/dist
+docs/.vitepress/cache

--- a/README.md
+++ b/README.md
@@ -16,6 +16,18 @@ It exports:
 - table-name helpers: `getTableName`, `toSnakeCase`
 - `DB`: initialised Knex instance (after `configure`)
 
+## Documentation
+
+**Site:** [https://stanleymasinde.github.io/mevn-orm/](https://stanleymasinde.github.io/mevn-orm/)
+
+Guides and API reference are built with VitePress (`docs/`). Deployed to GitHub Pages from `main` via [`.github/workflows/docs.yml`](./.github/workflows/docs.yml).
+
+```bash
+pnpm run docs:dev      # local docs site
+pnpm run docs:build    # static build to docs/.vitepress/dist
+pnpm run docs:preview  # preview the production build
+```
+
 ## Status
 
 This project is in maintenance mode. Core functionality is stable and actively maintained; large new features are limited.

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,0 +1,102 @@
+import { defineConfig } from 'vitepress'
+
+export default defineConfig({
+	// Project site: https://stanleymasinde.github.io/mevn-orm/
+	base: '/mevn-orm/',
+	title: 'Mevn ORM',
+	description: 'A small ActiveRecord-style ORM for Node.js, built on Knex',
+	lang: 'en-US',
+	cleanUrls: true,
+	lastUpdated: true,
+
+	head: [
+		['meta', { name: 'theme-color', content: '#3eaf7c' }],
+		['meta', { name: 'og:type', content: 'website' }],
+		['meta', { name: 'og:title', content: 'Mevn ORM' }],
+		['meta', { name: 'og:description', content: 'A small ActiveRecord-style ORM for Node.js, built on Knex' }],
+	],
+
+	themeConfig: {
+		logo: undefined,
+		siteTitle: 'Mevn ORM',
+		nav: [
+			{ text: 'Guide', link: '/guide/getting-started', activeMatch: '/guide/' },
+			{ text: 'API', link: '/api/', activeMatch: '/api/' },
+			{
+				text: 'v4.6',
+				items: [
+					{ text: 'Changelog', link: 'https://github.com/StanleyMasinde/mevn-orm/blob/main/changelog.md' },
+					{ text: 'npm', link: 'https://www.npmjs.com/package/mevn-orm' },
+				],
+			},
+		],
+
+		sidebar: {
+			'/guide/': [
+				{
+					text: 'Introduction',
+					items: [
+						{ text: 'What is Mevn ORM?', link: '/guide/what-is-mevn-orm' },
+						{ text: 'Getting Started', link: '/guide/getting-started' },
+					],
+				},
+				{
+					text: 'Core Concepts',
+					items: [
+						{ text: 'Configuration', link: '/guide/configuration' },
+						{ text: 'Models', link: '/guide/models' },
+						{ text: 'Queries', link: '/guide/queries' },
+						{ text: 'Relationships', link: '/guide/relationships' },
+						{ text: 'Serialization', link: '/guide/serialization' },
+						{ text: 'Migrations', link: '/guide/migrations' },
+					],
+				},
+				{
+					text: 'Recipes',
+					items: [
+						{ text: 'Express', link: '/guide/express' },
+						{ text: 'Nuxt / Nitro', link: '/guide/nuxt' },
+						{ text: 'Raw Knex (DB)', link: '/guide/raw-knex' },
+						{ text: 'Security', link: '/guide/security' },
+					],
+				},
+			],
+			'/api/': [
+				{
+					text: 'API Reference',
+					items: [
+						{ text: 'Overview', link: '/api/' },
+						{ text: 'Model', link: '/api/model' },
+						{ text: 'Configuration', link: '/api/configuration' },
+						{ text: 'Relationships', link: '/api/relationships' },
+						{ text: 'Migrations', link: '/api/migrations' },
+						{ text: 'Helpers', link: '/api/helpers' },
+					],
+				},
+			],
+		},
+
+		socialLinks: [
+			{ icon: 'github', link: 'https://github.com/StanleyMasinde/mevn-orm' },
+			{ icon: 'npm', link: 'https://www.npmjs.com/package/mevn-orm' },
+		],
+
+		editLink: {
+			pattern: 'https://github.com/StanleyMasinde/mevn-orm/edit/main/docs/:path',
+			text: 'Edit this page on GitHub',
+		},
+
+		footer: {
+			message: 'Released under the MIT License.',
+			copyright: 'Copyright © Stanley Masinde',
+		},
+
+		search: {
+			provider: 'local',
+		},
+
+		outline: {
+			level: [2, 3],
+		},
+	},
+})

--- a/docs/api/configuration.md
+++ b/docs/api/configuration.md
@@ -1,0 +1,107 @@
+# Configuration API
+
+## `configureDatabase(config): Knex`
+
+Initialises the ORM from simple options. Recommended for most applications.
+
+```ts
+import { configureDatabase } from 'mevn-orm'
+
+configureDatabase({
+  client: 'better-sqlite3',
+  connection: { filename: './dev.sqlite' }
+})
+```
+
+### `SimpleDatabaseConfig`
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `client` | string | Preferred driver selector |
+| `dialect` | string | Deprecated alias of `client` |
+| `connection` | Knex connection | Object or connection string |
+| `connectionString` | string | Alternative to `connection` string |
+| `filename` | string | SQLite path when not using `connection` |
+| `host`, `port`, `user`, `password`, `database` | | Top-level connection fields |
+| `ssl` | boolean \| object | Passed into connection when built from top-level fields |
+| `debug` | boolean | Knex debug flag |
+| `pool` | Knex pool config | Connection pool |
+
+### Client normalisation
+
+| Input | Resolved Knex client |
+| --- | --- |
+| `sqlite3`, `sqlite` | `better-sqlite3` |
+| `mysql` | `mysql2` |
+| `postgres`, `postgresql`, `pg` | `pg` |
+| `oracle` | `oracledb` |
+| others listed in types | as-is |
+
+SQLite configs set `useNullAsDefault: true`.
+
+### Errors
+
+- Missing `client` (and `dialect`): `Missing required field "client".`
+- Missing required host/user/database/filename for the client: `Missing required field "…" for client "…".`
+
+---
+
+## `createKnexConfig(config): Knex.Config`
+
+Builds a Knex config without setting the global client.
+
+```ts
+import { createKnexConfig, configure } from 'mevn-orm'
+
+const config = createKnexConfig({
+  client: 'pg',
+  connection: process.env.DATABASE_URL,
+  pool: { min: 0, max: 10 }
+})
+
+configure(config)
+```
+
+---
+
+## `configure(config: Knex.Config | Knex): Knex`
+
+Initialises from a full Knex config **or** an existing Knex instance.
+
+```ts
+import knex from 'knex'
+import { configure } from 'mevn-orm'
+
+configure({
+  client: 'pg',
+  connection: process.env.DATABASE_URL,
+  searchPath: ['public']
+})
+
+const db = knex({ /* ... */ })
+configure(db)
+```
+
+---
+
+## `getDB(): Knex`
+
+Returns the active Knex instance.
+
+```ts
+import { getDB } from 'mevn-orm'
+
+const rows = await getDB()('users').select('*')
+```
+
+Throws if not configured:
+
+```txt
+Mevn ORM is not configured. Call configure({ client, connection, ... }) before using Model.
+```
+
+---
+
+## `DB`
+
+Package export for the Knex instance. Prefer `getDB()` in application code so missing configuration fails loudly with a clear error.

--- a/docs/api/helpers.md
+++ b/docs/api/helpers.md
@@ -1,0 +1,43 @@
+# Helpers
+
+Table-name utilities used by `Model` and available for your own code.
+
+## `toSnakeCase(value: string): string`
+
+Converts PascalCase or camelCase to snake_case.
+
+```ts
+import { toSnakeCase } from 'mevn-orm'
+
+toSnakeCase('User')                 // 'user'
+toSnakeCase('PasswordResetToken')   // 'password_reset_token'
+toSnakeCase('XMLParser')            // depends on acronym handling via implementation
+```
+
+## `getTableName(className: string): string`
+
+Pluralised snake_case table name for a model class name.
+
+```ts
+import { getTableName } from 'mevn-orm'
+
+getTableName('User')                // 'users'
+getTableName('Farm')                // 'farms'
+getTableName('PasswordResetToken')  // 'password_reset_tokens'
+```
+
+Uses the `pluralize` package for pluralisation after snake_casing.
+
+## Usage outside models
+
+```ts
+import { getTableName, getDB } from 'mevn-orm'
+
+function tableFor(ModelClass: { name: string }) {
+  return getTableName(ModelClass.name)
+}
+
+await getDB()(tableFor(User)).select('*')
+```
+
+Prefer `Model.currentTable` / `override table` when working with model subclasses so explicit overrides are respected.

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,0 +1,80 @@
+# API Overview
+
+All public exports from `mevn-orm`.
+
+```ts
+import {
+  Model,
+  ModelCollection,
+  HasOneRelation,
+  HasManyRelation,
+  BelongsToRelation,
+  Relation,
+  configureDatabase,
+  createKnexConfig,
+  configure,
+  getDB,
+  DB,
+  setMigrationConfig,
+  getMigrationConfig,
+  makeMigration,
+  migrateLatest,
+  migrateRollback,
+  migrateCurrentVersion,
+  migrateList,
+  getTableName,
+  toSnakeCase,
+} from 'mevn-orm'
+
+import type { PaginatedResult } from 'mevn-orm'
+```
+
+## Models & collections
+
+| Export | Description |
+| --- | --- |
+| [`Model`](/api/model) | ActiveRecord base class |
+| `ModelCollection` | `Array` subclass from `all()` / `paginate().data` with `toArray()` |
+| `PaginatedResult` | Type for pagination results |
+
+## Configuration
+
+| Export | Description |
+| --- | --- |
+| [`configureDatabase`](/api/configuration#configuredatabase) | Initialise from simple options (recommended) |
+| [`createKnexConfig`](/api/configuration#createknexconfig) | Build Knex config without initialising |
+| [`configure`](/api/configuration#configure) | Initialise from Knex config or instance |
+| [`getDB`](/api/configuration#getdb) | Active Knex instance (throws if unconfigured) |
+| `DB` | Knex instance export (available after configure) |
+
+## Relationships
+
+| Export | Description |
+| --- | --- |
+| [`HasOneRelation`](/api/relationships) | One-to-one lazy relation |
+| [`HasManyRelation`](/api/relationships) | One-to-many lazy relation |
+| [`BelongsToRelation`](/api/relationships) | Belongs-to lazy relation |
+| `Relation` | Abstract base (Promise-like) |
+
+## Migrations
+
+| Export | Description |
+| --- | --- |
+| [`setMigrationConfig`](/api/migrations) | Default migrator options |
+| `getMigrationConfig` | Read defaults |
+| `makeMigration` | Generate a migration file |
+| `migrateLatest` | Run pending migrations |
+| `migrateRollback` | Roll back batch(es) |
+| `migrateCurrentVersion` | Current version string |
+| `migrateList` | Completed and pending filenames |
+
+## Helpers
+
+| Export | Description |
+| --- | --- |
+| [`getTableName`](/api/helpers) | Pluralised snake_case table name from a class name |
+| [`toSnakeCase`](/api/helpers) | PascalCase / camelCase → snake_case |
+
+## Guides
+
+For narrative tutorials and end-to-end examples, start with the [Getting Started](/guide/getting-started) guide.

--- a/docs/api/migrations.md
+++ b/docs/api/migrations.md
@@ -1,0 +1,83 @@
+# Migrations API
+
+Thin wrappers around Knex’s migrator. Configure the database first, then set default migrator options.
+
+## `setMigrationConfig(config): Knex.MigratorConfig`
+
+Stores default options (typically `directory` and `extension`).
+
+```ts
+import { setMigrationConfig } from 'mevn-orm'
+
+setMigrationConfig({
+  directory: './migrations',
+  extension: 'ts'
+})
+```
+
+Returns a **copy** of the stored config.
+
+## `getMigrationConfig(): Knex.MigratorConfig`
+
+Returns a copy of the current defaults.
+
+## Shared options
+
+Each helper accepts an optional `config?: Knex.MigratorConfig` that is merged over the defaults for that call only:
+
+```ts
+await migrateLatest({ directory: './alt-migrations' })
+```
+
+---
+
+## `makeMigration(name, config?): Promise<string>`
+
+Generates a migration file; returns its absolute path.
+
+```ts
+const path = await makeMigration('create_users_table')
+```
+
+## `migrateLatest(config?): Promise<{ batch: number; log: string[] }>`
+
+Runs all pending migrations.
+
+```ts
+const { batch, log } = await migrateLatest()
+```
+
+## `migrateRollback(config?, all?): Promise<{ batch: number; log: string[] }>`
+
+Rolls back the last batch. Pass `all: true` to roll back every completed batch.
+
+```ts
+await migrateRollback()           // last batch
+await migrateRollback(undefined, true) // all
+```
+
+## `migrateCurrentVersion(config?): Promise<string>`
+
+Latest applied migration name, or `'none'`.
+
+```ts
+const version = await migrateCurrentVersion()
+```
+
+## `migrateList(config?): Promise<{ completed: string[]; pending: string[] }>`
+
+Filename lists for completed and pending migrations.
+
+```ts
+const { completed, pending } = await migrateList()
+```
+
+---
+
+## Errors
+
+Helpers rethrow as `Error` instances (wrapping non-Error throws). Ensure `configure` / `configureDatabase` ran before any migration call — otherwise `getDB()` fails first.
+
+## Guide
+
+See [Migrations](/guide/migrations) and [Nuxt / Nitro](/guide/nuxt).

--- a/docs/api/model.md
+++ b/docs/api/model.md
@@ -1,0 +1,215 @@
+# Model
+
+ActiveRecord-style base class backed by Knex. Extend for each table.
+
+```ts
+import { Model } from 'mevn-orm'
+
+class User extends Model {
+  override fillable = ['name', 'email', 'password']
+  override hidden = ['password']
+}
+```
+
+## Instance properties
+
+### `fillable: string[]`
+
+Attributes allowed through instance [`save()`](#save). Default `[]`.
+
+### `hidden: string[]`
+
+Attributes excluded from [`toArray()`](#toarray) and stripped after many read/create paths. Default `[]`.
+
+### `table: string`
+
+Database table. Defaults to plural snake_case of the class name. Override when inference is wrong:
+
+```ts
+class PasswordReset extends Model {
+  override table = 'password_reset_tokens'
+}
+```
+
+### `modelName: string`
+
+Snake_case singular form of the class name (e.g. `PasswordResetToken` → `password_reset_token`). Used for default foreign key names on relations.
+
+### `id?: number`
+
+Primary key after insert or load.
+
+---
+
+## Static properties & helpers
+
+### `static currentTable: string`
+
+Resolved table name for the class (honours `override table`).
+
+### `static resolveTable(): string`
+
+Same resolution as `currentTable`.
+
+### `static currentQuery`
+
+Internal scoped Knex builder. Set by chain methods; cleared by terminal methods. Prefer not to touch this directly.
+
+### `static ensureCurrentQuery()`
+
+Returns `currentQuery`, creating `getDB()(table)` when absent. Used by `orderBy` / `limit` / `offset` without a prior `where`.
+
+---
+
+## Instance methods
+
+### `constructor(properties?: Record<string, unknown>)`
+
+Assigns properties, initialises `fillable` / `hidden`, and sets `modelName` / `table` from the class name.
+
+### `save(): Promise<this>`
+
+Inserts using **only** `fillable` fields, reloads the row, sets `id`, and returns `this`.
+
+```ts
+const user = new User()
+user.name = 'Jane'
+user.email = 'jane@example.com'
+user.password = hashed
+await user.save()
+```
+
+### `update(properties): Promise<this>`
+
+Updates the row by `id`, reloads, returns a new instance of the same class. Throws if `id` is missing.
+
+```ts
+const updated = await user.update({ name: 'Jane Updated' })
+```
+
+### `delete(): Promise<void>`
+
+Deletes by `id`. Throws if `id` is missing.
+
+### `toArray(): Record<string, unknown>`
+
+Plain object for API responses. Omits `fillable`, `hidden`, `modelName`, `table`, function values, and all `hidden` attributes.
+
+### `stripColumns(model, keepInternalState?): T`
+
+Removes private / hidden keys from a model object in place. Used internally after loads.
+
+### Relationship helpers
+
+Documented under [Relationships](/api/relationships):
+
+- `hasOne(Related, localKey?, foreignKey?)`
+- `hasMany(Related, localKey?, foreignKey?)`
+- `belongsTo(Related, foreignKey?, ownerKey?)`
+
+---
+
+## Static CRUD
+
+All static methods that return models preserve the **derived** type (`User.find` → `User | null`).
+
+### `static find(id, columns?): Promise<InstanceType<T> | null>`
+
+Find by primary key. Returns `null` when missing.
+
+```ts
+const user = await User.find(1)
+const partial = await User.find(1, ['id', 'email'])
+```
+
+### `static findOrFail(id, columns?): Promise<InstanceType<T>>`
+
+Like `find`, but throws `Error: ${Name} with id "${id}" not found`.
+
+### `static create(properties): Promise<InstanceType<T>>`
+
+Insert one row and return a model instance (hidden fields stripped).
+
+```ts
+const user = await User.create({ name, email, password: hashed })
+```
+
+### `static createMany(properties[]): Promise<InstanceType<T>[]>`
+
+Insert many rows sequentially. Empty array returns `[]`.
+
+### `static firstOrCreate(attributes, values?): Promise<InstanceType<T>>`
+
+Return the first row matching `attributes`, or create with `{ ...attributes, ...values }`.
+
+```ts
+const user = await User.firstOrCreate(
+  { email: 'jane@example.com' },
+  { name: 'Jane', password: hashed }
+)
+```
+
+### `static update(properties): Promise<number | undefined>`
+
+Bulk update. Uses the current scope if set via `where()`, otherwise the whole table. Resets scope afterwards.
+
+### `static destroy(): Promise<number | undefined>`
+
+Bulk delete. Same scoping rules as `update`.
+
+---
+
+## Static query builder
+
+Chain scopes, then a terminal method. Scope resets after terminals.
+
+### Scopes
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `where` | `where(conditions?: Row): typeof Model` | Knex equality object |
+| `orderBy` | `orderBy(column, direction?: 'asc' \| 'desc')` | Default `'asc'` |
+| `limit` | `limit(count: number)` | |
+| `offset` | `offset(count: number)` | |
+
+```ts
+User.where({ active: true }).orderBy('name').limit(10).all()
+```
+
+### Terminals
+
+| Method | Returns |
+| --- | --- |
+| `first(columns?)` | `InstanceType<T> \| null` |
+| `all(columns?)` | `ModelCollection<InstanceType<T>>` |
+| `count(column?)` | `number` (default column `*`) |
+| `paginate(perPage?, page?, columns?)` | `PaginatedResult<InstanceType<T>>` |
+| `update` / `destroy` | row counts |
+
+Default `perPage` for `paginate` is **15**; default `page` is **1**.
+
+### `PaginatedResult<T>`
+
+```ts
+interface PaginatedResult<T extends Model> {
+  data: ModelCollection<T>
+  total: number
+  per_page: number
+  current_page: number
+  next_page: number | null
+  prev_page: number | null
+  last_page: number
+}
+```
+
+---
+
+## ModelCollection
+
+```ts
+class ModelCollection<T extends Model> extends Array<T> {
+  toArray(): Record<string, unknown>[]
+}
+```
+
+Returned by `all()` and `paginate().data`. Supports normal array methods plus collection-level serialisation.

--- a/docs/api/relationships.md
+++ b/docs/api/relationships.md
@@ -1,0 +1,129 @@
+# Relationships API
+
+Relation helpers live on `Model` instances. They return Promise-like wrappers you can `await` or chain.
+
+## Model methods
+
+### `hasOne(Related, localKey?, foreignKey?): HasOneRelation`
+
+One-to-one from this model to `Related`.
+
+| Param | Default |
+| --- | --- |
+| `localKey` | parent primary key (`id`) |
+| `foreignKey` | `{this.modelName}_id` |
+
+```ts
+class Farmer extends Model {
+  profile() {
+    return this.hasOne(Profile)
+    // profiles.farmer_id = this.id
+  }
+}
+
+const profile = await farmer.profile() // Profile | null
+```
+
+### `hasMany(Related, localKey?, foreignKey?): HasManyRelation`
+
+One-to-many. Same key defaults as `hasOne`.
+
+```ts
+class Farmer extends Model {
+  farms() {
+    return this.hasMany(Farm)
+  }
+}
+
+const farms = await farmer.farms() // Farm[]
+const active = await farmer.farms().where({ active: true }).get()
+```
+
+### `belongsTo(Related, foreignKey?, ownerKey?): BelongsToRelation`
+
+Inverse relation.
+
+| Param | Default |
+| --- | --- |
+| `foreignKey` | required for correct SQL in practice |
+| `ownerKey` | `id` on the related table |
+
+```ts
+class Farm extends Model {
+  farmer() {
+    return this.belongsTo(Farmer, 'farmer_id')
+  }
+}
+
+const owner = await farm.farmer() // Farmer | null
+```
+
+---
+
+## Relation classes
+
+All extend abstract `Relation` and implement `PromiseLike`.
+
+### Shared API
+
+```ts
+abstract class Relation<TResult, TRelated> implements PromiseLike<TResult> {
+  where(...args: unknown[]): this
+  first(columns?: string | string[]): Promise<TRelated | null>
+  get(columns?: string | string[]): Promise<TRelated[]>
+  then(...) // enables await relation
+}
+```
+
+#### `where(...args)`
+
+Forwards to Knex `where`. Supports object form and other Knex signatures:
+
+```ts
+relation.where({ active: true })
+relation.where('region', 'west')
+```
+
+#### `first(columns?)`
+
+Executes and returns one related model or `null`.
+
+#### `get(columns?)`
+
+Executes and returns an array of related models (empty if none).
+
+#### `await relation`
+
+Calls the subclass `resolve()`:
+
+| Class | `resolve()` |
+| --- | --- |
+| `HasOneRelation` | `first()` → `T \| null` |
+| `HasManyRelation` | `get()` → `T[]` |
+| `BelongsToRelation` | `first()` → `T \| null` |
+
+### Null query guards
+
+If the parent lacks a key needed to build the query (e.g. no `id`), the internal query may be `null`. Then:
+
+- `first()` → `null`
+- `get()` → `[]`
+
+---
+
+## Exports
+
+```ts
+import {
+  Relation,
+  HasOneRelation,
+  HasManyRelation,
+  BelongsToRelation
+} from 'mevn-orm'
+```
+
+These are useful for typing; day-to-day code usually only uses the `Model` helpers.
+
+## Guide
+
+See [Relationships](/guide/relationships) for end-to-end examples.

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -1,0 +1,243 @@
+# Configuration
+
+Mevn ORM must be configured **once** before any `Model` method runs. Prefer `configureDatabase` for most apps; use `configure` when you already have a Knex config or instance.
+
+## `configureDatabase` (recommended)
+
+```ts
+import { configureDatabase } from 'mevn-orm'
+
+configureDatabase({
+  client: 'better-sqlite3',
+  connection: {
+    filename: './dev.sqlite'
+  }
+})
+```
+
+### Supported clients
+
+| Input `client` | Knex driver used |
+| --- | --- |
+| `better-sqlite3` | `better-sqlite3` (preferred SQLite) |
+| `sqlite3`, `sqlite` | `better-sqlite3` (aliases) |
+| `mysql2`, `mysql` | `mysql2` |
+| `pg`, `postgres`, `postgresql` | `pg` |
+| `pgnative`, `cockroachdb`, `redshift` | as named / via `pg` family |
+| `mssql` | `mssql` |
+| `oracledb`, `oracle` | `oracledb` |
+
+A deprecated `dialect` field is still accepted for backwards compatibility. Prefer **`client`**.
+
+### Connection styles
+
+#### Connection object
+
+```ts
+configureDatabase({
+  client: 'mysql2',
+  connection: {
+    host: '127.0.0.1',
+    port: 3306,
+    user: 'root',
+    password: 'secret',
+    database: 'app_db'
+  }
+})
+```
+
+#### Connection string
+
+```ts
+configureDatabase({
+  client: 'pg',
+  connection: process.env.DATABASE_URL
+})
+
+// or via connectionString
+configureDatabase({
+  client: 'pg',
+  connectionString: process.env.DATABASE_URL
+})
+```
+
+#### SQLite file
+
+```ts
+configureDatabase({
+  client: 'better-sqlite3',
+  connection: {
+    filename: './dev.sqlite'
+  }
+})
+
+// top-level filename also works
+configureDatabase({
+  client: 'better-sqlite3',
+  filename: './dev.sqlite'
+})
+```
+
+#### Top-level host fields
+
+```ts
+configureDatabase({
+  client: 'mysql2',
+  host: '127.0.0.1',
+  port: 3306,
+  user: 'root',
+  password: 'secret',
+  database: 'app_db'
+})
+```
+
+#### MSSQL
+
+```ts
+configureDatabase({
+  client: 'mssql',
+  connection: {
+    host: '127.0.0.1',
+    user: 'sa',
+    password: 'StrongPassword!',
+    database: 'app_db',
+    // MSSQL driver options live under `options` (passed through to tedious)
+    options: {
+      encrypt: true
+    }
+  }
+})
+```
+
+#### Pool and debug
+
+```ts
+configureDatabase({
+  client: 'pg',
+  connection: process.env.DATABASE_URL,
+  pool: {
+    min: 2,
+    max: 10
+  },
+  debug: process.env.NODE_ENV !== 'production'
+})
+```
+
+SQLite configs automatically set `useNullAsDefault: true` for Knex.
+
+## `createKnexConfig`
+
+Build a Knex config **without** initialising the global client (useful for tests or dual connections):
+
+```ts
+import { createKnexConfig, configure } from 'mevn-orm'
+import knex from 'knex'
+
+const config = createKnexConfig({
+  client: 'better-sqlite3',
+  connection: { filename: ':memory:' }
+})
+
+// Inspect or merge, then configure
+configure(config)
+
+// Or use Knex yourself
+const db = knex(config)
+```
+
+## `configure` (advanced)
+
+Pass a full Knex config or an existing Knex instance:
+
+```ts
+import knex from 'knex'
+import { configure } from 'mevn-orm'
+
+// Full Knex config
+configure({
+  client: 'pg',
+  connection: process.env.DATABASE_URL,
+  searchPath: ['knex', 'public'],
+  pool: { min: 0, max: 7 }
+})
+
+// Existing instance
+const db = knex({ client: 'better-sqlite3', connection: { filename: './dev.sqlite' }, useNullAsDefault: true })
+configure(db)
+```
+
+## Accessing Knex
+
+```ts
+import { DB, getDB } from 'mevn-orm'
+
+// After configure / configureDatabase:
+const users = await getDB()('users').select('*')
+
+// DB is the same instance once configured (see package export notes)
+```
+
+`getDB()` throws if the ORM has not been configured yet:
+
+```txt
+Mevn ORM is not configured. Call configure({ client, connection, ... }) before using Model.
+```
+
+## Environment-based setup
+
+```ts
+// src/db.ts
+import { configureDatabase } from 'mevn-orm'
+
+export function initDatabase() {
+  const client = (process.env.DB_CLIENT ?? 'better-sqlite3') as 'better-sqlite3' | 'mysql2' | 'pg'
+
+  if (client === 'better-sqlite3') {
+    configureDatabase({
+      client,
+      connection: { filename: process.env.DB_FILENAME ?? './dev.sqlite' }
+    })
+    return
+  }
+
+  if (process.env.DATABASE_URL) {
+    configureDatabase({
+      client,
+      connection: process.env.DATABASE_URL
+    })
+    return
+  }
+
+  configureDatabase({
+    client,
+    connection: {
+      host: process.env.DB_HOST,
+      port: Number(process.env.DB_PORT),
+      user: process.env.DB_USER,
+      password: process.env.DB_PASSWORD,
+      database: process.env.DB_NAME
+    }
+  })
+}
+```
+
+## Example env file
+
+```bash
+# .env.example
+DB_CLIENT=mysql2
+DB_HOST=127.0.0.1
+DB_PORT=3306
+DB_USER=root
+DB_PASSWORD=
+DB_NAME=app_db
+
+# Or use a URL
+# DATABASE_URL=postgres://user:pass@localhost:5432/app_db
+```
+
+## Next steps
+
+- [Models](/guide/models)
+- [Migrations](/guide/migrations)
+- [Raw Knex](/guide/raw-knex)

--- a/docs/guide/express.md
+++ b/docs/guide/express.md
@@ -1,0 +1,223 @@
+# Express
+
+Wire Mevn ORM into an Express app: configure once at startup, define models, and use them in route handlers.
+
+## Project sketch
+
+```
+app/
+├── src/
+│   ├── db.ts
+│   ├── models/
+│   │   └── User.ts
+│   ├── routes/
+│   │   └── users.ts
+│   └── index.ts
+├── migrations/
+└── package.json
+```
+
+## Configure at boot
+
+```ts
+// src/db.ts
+import { configureDatabase, setMigrationConfig } from 'mevn-orm'
+
+export function initDatabase() {
+  configureDatabase({
+    client: (process.env.DB_CLIENT as 'mysql2' | 'pg' | 'better-sqlite3') ?? 'mysql2',
+    connection: process.env.DATABASE_URL ?? {
+      host: process.env.DB_HOST ?? '127.0.0.1',
+      port: Number(process.env.DB_PORT ?? 3306),
+      user: process.env.DB_USER ?? 'root',
+      password: process.env.DB_PASSWORD ?? '',
+      database: process.env.DB_NAME ?? 'app'
+    }
+  })
+
+  setMigrationConfig({
+    directory: new URL('../migrations', import.meta.url).pathname,
+    extension: 'ts'
+  })
+}
+```
+
+```ts
+// src/index.ts
+import express from 'express'
+import { initDatabase } from './db.js'
+import usersRouter from './routes/users.js'
+
+initDatabase()
+
+const app = express()
+app.use(express.json())
+app.use('/users', usersRouter)
+
+app.listen(3000, () => {
+  console.log('http://localhost:3000')
+})
+```
+
+## Model
+
+```ts
+// src/models/User.ts
+import { Model } from 'mevn-orm'
+
+export class User extends Model {
+  override fillable = ['name', 'email', 'password']
+  override hidden = ['password']
+}
+```
+
+## Routes with full CRUD
+
+```ts
+// src/routes/users.ts
+import { Router } from 'express'
+import bcrypt from 'bcrypt'
+import { User } from '../models/User.js'
+
+const router = Router()
+
+// List (paginated)
+router.get('/', async (req, res, next) => {
+  try {
+    const page = Number(req.query.page ?? 1)
+    const perPage = Number(req.query.perPage ?? 15)
+    const result = await User.orderBy('id', 'desc').paginate(perPage, page)
+
+    res.json({
+      data: result.data.toArray(),
+      meta: {
+        total: result.total,
+        per_page: result.per_page,
+        current_page: result.current_page,
+        next_page: result.next_page,
+        prev_page: result.prev_page,
+        last_page: result.last_page
+      }
+    })
+  } catch (error) {
+    next(error)
+  }
+})
+
+// Show
+router.get('/:id', async (req, res, next) => {
+  try {
+    const user = await User.find(Number(req.params.id))
+    if (!user) {
+      return res.status(404).json({ error: 'User not found' })
+    }
+    res.json(user.toArray())
+  } catch (error) {
+    next(error)
+  }
+})
+
+// Create
+router.post('/', async (req, res, next) => {
+  try {
+    const { name, email, password } = req.body
+    if (!name || !email || !password) {
+      return res.status(400).json({ error: 'name, email, and password are required' })
+    }
+
+    const hashed = await bcrypt.hash(password, 12)
+    const user = await User.create({ name, email, password: hashed })
+    res.status(201).json(user.toArray())
+  } catch (error) {
+    next(error)
+  }
+})
+
+// Update
+router.patch('/:id', async (req, res, next) => {
+  try {
+    const user = await User.find(Number(req.params.id))
+    if (!user) {
+      return res.status(404).json({ error: 'User not found' })
+    }
+
+    const payload: Record<string, unknown> = {}
+    if (req.body.name !== undefined) payload.name = req.body.name
+    if (req.body.email !== undefined) payload.email = req.body.email
+    if (req.body.password) {
+      payload.password = await bcrypt.hash(req.body.password, 12)
+    }
+
+    const updated = await user.update(payload)
+    res.json(updated.toArray())
+  } catch (error) {
+    next(error)
+  }
+})
+
+// Delete
+router.delete('/:id', async (req, res, next) => {
+  try {
+    const user = await User.find(Number(req.params.id))
+    if (!user) {
+      return res.status(404).json({ error: 'User not found' })
+    }
+    await user.delete()
+    res.status(204).end()
+  } catch (error) {
+    next(error)
+  }
+})
+
+export default router
+```
+
+## Filter + sort example
+
+```ts
+router.get('/search', async (req, res, next) => {
+  try {
+    let query = User as typeof User
+
+    if (req.query.email) {
+      query = query.where({ email: String(req.query.email) })
+    }
+
+    const users = await query
+      .orderBy('created_at', 'desc')
+      .limit(50)
+      .all()
+
+    res.json(users.toArray())
+  } catch (error) {
+    next(error)
+  }
+})
+```
+
+::: warning Query chain typing
+`where` / `orderBy` return the model constructor for chaining. Prefer a single fluent chain rather than reassigning mid-handler when TypeScript gets noisy:
+
+```ts
+const users = await User
+  .where({ email: String(req.query.email) })
+  .orderBy('id', 'desc')
+  .all()
+```
+:::
+
+## Error middleware
+
+```ts
+app.use((error: unknown, _req, res, _next) => {
+  console.error(error)
+  const message = error instanceof Error ? error.message : 'Server error'
+  res.status(500).json({ error: message })
+})
+```
+
+## Next steps
+
+- [Relationships](/guide/relationships) in nested resources
+- [Security](/guide/security)
+- [Nuxt / Nitro](/guide/nuxt) if you use Nuxt server routes instead

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -1,0 +1,148 @@
+# Getting Started
+
+Install Mevn ORM, configure a database, define a model, and run your first queries.
+
+## Installation
+
+```bash
+npm install mevn-orm knex
+# or
+pnpm add mevn-orm knex
+# or
+yarn add mevn-orm knex
+```
+
+Install a driver for your database:
+
+```bash
+# MySQL
+npm install mysql2
+
+# PostgreSQL
+npm install pg
+
+# SQLite (recommended driver)
+npm install better-sqlite3
+```
+
+::: tip SQLite driver
+Use **`better-sqlite3`**. The older `sqlite3` package is discouraged because it needs native compilation. Mevn ORM maps `client: 'sqlite3'` and `client: 'sqlite'` to the Knex **`better-sqlite3`** driver, so install `better-sqlite3` even if you pass those client names for compatibility.
+:::
+
+## Minimal example
+
+```ts
+import { configureDatabase, Model } from 'mevn-orm'
+
+// 1. Configure once at app startup
+configureDatabase({
+  client: 'better-sqlite3',
+  connection: {
+    filename: './dev.sqlite'
+  }
+})
+
+// 2. Define a model
+class User extends Model {
+  override fillable = ['name', 'email', 'password']
+  override hidden = ['password']
+}
+
+// 3. Use it
+async function main() {
+  const created = await User.create({
+    name: 'Jane Doe',
+    email: 'jane@example.com',
+    password: 'hash-me-first' // always hash before persisting
+  })
+
+  const found = await User.find(created.id as number)
+  await found?.update({ name: 'Jane Updated' })
+
+  const users = await User.where({ name: 'Jane Updated' }).all()
+  console.log(users.toArray())
+  // [{ id: 1, name: 'Jane Updated', email: 'jane@example.com' }]
+}
+
+main()
+```
+
+## Project layout (suggested)
+
+```
+my-app/
+├── src/
+│   ├── db.ts          # configureDatabase + migration config
+│   ├── models/
+│   │   ├── User.ts
+│   │   └── Post.ts
+│   └── index.ts       # Express / Nitro entry
+├── migrations/
+└── package.json
+```
+
+### `src/db.ts`
+
+```ts
+import { configureDatabase, setMigrationConfig } from 'mevn-orm'
+
+export function initDatabase() {
+  configureDatabase({
+    client: 'mysql2',
+    connection: {
+      host: process.env.DB_HOST ?? '127.0.0.1',
+      port: Number(process.env.DB_PORT ?? 3306),
+      user: process.env.DB_USER ?? 'root',
+      password: process.env.DB_PASSWORD ?? '',
+      database: process.env.DB_NAME ?? 'app_db'
+    }
+  })
+
+  setMigrationConfig({
+    directory: './migrations',
+    extension: 'ts'
+  })
+}
+```
+
+### `src/models/User.ts`
+
+```ts
+import { Model } from 'mevn-orm'
+import type { Post } from './Post.js'
+
+export class User extends Model {
+  override fillable = ['name', 'email', 'password']
+  override hidden = ['password']
+
+  posts() {
+    return this.hasMany(Post as typeof Model)
+  }
+}
+```
+
+## Table names
+
+Table names are inferred from the class name:
+
+| Class | Table |
+| --- | --- |
+| `User` | `users` |
+| `PasswordResetToken` | `password_reset_tokens` |
+| `Farm` | `farms` |
+
+Override when your schema differs:
+
+```ts
+class PasswordResetToken extends Model {
+  override table = 'password_reset_tokens'
+}
+```
+
+## Next steps
+
+- [Configuration](/guide/configuration) — all clients and connection styles
+- [Models](/guide/models) — fillable, hidden, instance CRUD
+- [Queries](/guide/queries) — where, orderBy, pagination
+- [Relationships](/guide/relationships) — hasOne, hasMany, belongsTo
+- [Migrations](/guide/migrations) — create and run schema migrations

--- a/docs/guide/migrations.md
+++ b/docs/guide/migrations.md
@@ -1,0 +1,185 @@
+# Migrations
+
+Migrations are programmatic and use Knex’s migration API under the hood. Configure a directory once, then generate and run migrations from code or npm scripts.
+
+## Setup
+
+```ts
+import {
+  configureDatabase,
+  setMigrationConfig
+} from 'mevn-orm'
+
+configureDatabase({
+  client: 'better-sqlite3',
+  connection: { filename: './dev.sqlite' }
+})
+
+setMigrationConfig({
+  directory: './migrations',
+  extension: 'ts' // or 'js'
+})
+```
+
+`setMigrationConfig` stores defaults used by all migration helpers. Pass a per-call config object to override.
+
+## Programmatic API
+
+```ts
+import {
+  makeMigration,
+  migrateLatest,
+  migrateRollback,
+  migrateList,
+  migrateCurrentVersion
+} from 'mevn-orm'
+
+// Create a new migration file
+const path = await makeMigration('create_users_table')
+console.log('Wrote', path)
+
+// Run pending migrations
+const latest = await migrateLatest()
+// { batch: 1, log: ['20260101120000_create_users_table.ts'] }
+
+// Inspect
+const { completed, pending } = await migrateList()
+const version = await migrateCurrentVersion() // filename or 'none'
+
+// Roll back last batch
+await migrateRollback()
+
+// Roll back all batches
+await migrateRollback(undefined, true)
+```
+
+### Override directory for one call
+
+```ts
+await migrateLatest({ directory: './server/assets/migrations' })
+```
+
+## Writing a migration
+
+Generated files follow Knex’s shape:
+
+```js
+/**
+ * @param {import('knex').Knex} knex
+ */
+export async function up(knex) {
+  await knex.schema.createTable('users', (table) => {
+    table.increments('id').primary()
+    table.string('name').notNullable()
+    table.string('email').notNullable().unique()
+    table.string('password').notNullable()
+    table.timestamps(true, true)
+  })
+}
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+export async function down(knex) {
+  await knex.schema.dropTableIfExists('users')
+}
+```
+
+TypeScript example:
+
+```ts
+import type { Knex } from 'knex'
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.createTable('posts', (table) => {
+    table.increments('id').primary()
+    table.integer('user_id').unsigned().notNullable()
+      .references('id').inTable('users').onDelete('CASCADE')
+    table.string('title').notNullable()
+    table.text('body')
+    table.boolean('published').notNullable().defaultTo(false)
+    table.timestamps(true, true)
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTableIfExists('posts')
+}
+```
+
+### Multi-table migration
+
+```ts
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.createTable('farmers', (table) => {
+    table.increments('id').primary()
+    table.string('name').notNullable()
+    table.string('email').notNullable().unique()
+    table.string('password').notNullable()
+  })
+
+  await knex.schema.createTable('profiles', (table) => {
+    table.increments('id').primary()
+    table.integer('farmer_id').unsigned().notNullable()
+      .references('id').inTable('farmers').onDelete('CASCADE')
+    table.text('bio')
+  })
+
+  await knex.schema.createTable('farms', (table) => {
+    table.increments('id').primary()
+    table.integer('farmer_id').unsigned().notNullable()
+      .references('id').inTable('farmers').onDelete('CASCADE')
+    table.string('name').notNullable()
+    table.string('region')
+    table.boolean('active').defaultTo(true)
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTableIfExists('farms')
+  await knex.schema.dropTableIfExists('profiles')
+  await knex.schema.dropTableIfExists('farmers')
+}
+```
+
+## Repository CLI scripts
+
+This package ships npm scripts that wrap the helpers (no `knexfile` required when env/config is set):
+
+```bash
+pnpm run migrate
+pnpm run migrate:make -- create_users_table
+pnpm run migrate:rollback
+pnpm run migrate:list
+pnpm run migrate:version
+```
+
+Typical `package.json` entries in an app:
+
+```json
+{
+  "scripts": {
+    "migrate": "node --import tsx ./scripts/migrate.ts latest",
+    "migrate:make": "node --import tsx ./scripts/migrate.ts make",
+    "migrate:rollback": "node --import tsx ./scripts/migrate.ts rollback"
+  }
+}
+```
+
+## Boot-time migrations (apps)
+
+Running `migrateLatest()` at process start is fine if you treat “already migrated” as success (Knex returns an empty log). See [Nuxt / Nitro](/guide/nuxt) for a production-oriented pattern that copies migration files into the build output.
+
+```ts
+try {
+  await migrateLatest()
+} catch (error) {
+  // filter ignorable "already exists" style errors if you need idempotent boots
+  throw error
+}
+```
+
+## Next steps
+
+- [Nuxt / Nitro](/guide/nuxt)
+- [API: Migrations](/api/migrations)

--- a/docs/guide/models.md
+++ b/docs/guide/models.md
@@ -1,0 +1,223 @@
+# Models
+
+Models are ActiveRecord-style classes that map to a database table. Extend `Model`, configure mass-assignment and serialization, then use static and instance methods for persistence.
+
+## Defining a model
+
+```ts
+import { Model } from 'mevn-orm'
+
+class User extends Model {
+  /** Columns allowed when calling instance `save()`. */
+  override fillable = ['name', 'email', 'password']
+
+  /** Columns excluded from `toArray()` and stripped after reads. */
+  override hidden = ['password']
+}
+```
+
+### Configuration properties
+
+| Property | Description |
+| --- | --- |
+| `fillable` | Attributes allowed through instance `save()` mass assignment |
+| `hidden` | Attributes excluded from `toArray()` and stripped after reads |
+| `table` | Override the inferred database table name |
+| `id` | Primary key (set after insert / find) |
+| `modelName` | Snake_case singular name from the class name (used for default foreign keys) |
+
+### Table name inference
+
+```ts
+class User extends Model {}
+// table → "users"
+
+class PasswordResetToken extends Model {}
+// table → "password_reset_tokens"
+
+class PasswordReset extends Model {
+  override table = 'password_reset_tokens' // force a specific table
+}
+```
+
+Helpers used under the hood:
+
+```ts
+import { getTableName, toSnakeCase } from 'mevn-orm'
+
+getTableName('PasswordResetToken') // 'password_reset_tokens'
+toSnakeCase('PasswordResetToken')  // 'password_reset_token'
+```
+
+## Creating records
+
+### `Model.create`
+
+```ts
+const user = await User.create({
+  name: 'Jane Doe',
+  email: 'jane@example.com',
+  password: hashedPassword
+})
+
+console.log(user.id)   // 1
+console.log(user.name) // 'Jane Doe'
+// password is stripped because it is in `hidden`
+```
+
+### `Model.createMany`
+
+```ts
+const users = await User.createMany([
+  { name: 'Ada', email: 'ada@example.com', password: hash1 },
+  { name: 'Grace', email: 'grace@example.com', password: hash2 }
+])
+```
+
+### Instance `save()`
+
+`save()` only persists fields listed in `fillable`:
+
+```ts
+const user = new User()
+user.name = 'Linus'
+user.email = 'linus@example.com'
+user.password = hashedPassword
+// user.role = 'admin'  // ignored by save() unless listed in fillable
+
+await user.save()
+// user.id is now set; row reloaded from the database
+```
+
+### `firstOrCreate`
+
+Find by attributes, or create with merged values:
+
+```ts
+const user = await User.firstOrCreate(
+  { email: 'jane@example.com' },
+  { name: 'Jane Doe', password: hashedPassword }
+)
+
+// Second call with the same email returns the existing row
+const same = await User.firstOrCreate({ email: 'jane@example.com' })
+```
+
+## Reading records
+
+```ts
+// By primary key
+const user = await User.find(1)           // User | null
+const user2 = await User.findOrFail(1)    // User, or throws
+
+// Select specific columns
+const partial = await User.find(1, ['id', 'email'])
+
+// First / all (see Queries guide for scopes)
+const first = await User.first()
+const all = await User.all()
+```
+
+`findOrFail` throws a clear error when missing:
+
+```ts
+try {
+  await User.findOrFail(999)
+} catch (error) {
+  // Error: User with id "999" not found
+}
+```
+
+Static methods preserve the **derived class type** in TypeScript:
+
+```ts
+const u: User | null = await User.find(1)
+// not Model | null
+```
+
+## Updating records
+
+### Instance update
+
+```ts
+const user = await User.findOrFail(1)
+const updated = await user.update({ name: 'Jane Updated' })
+console.log(updated.name) // 'Jane Updated'
+```
+
+Requires `id` on the instance. Throws if missing.
+
+### Bulk update
+
+```ts
+// All rows (use carefully)
+await User.update({ archived: true })
+
+// Scoped
+await User.where({ active: false }).update({ archived: true })
+```
+
+## Deleting records
+
+### Instance delete
+
+```ts
+const user = await User.findOrFail(1)
+await user.delete()
+```
+
+### Bulk destroy
+
+```ts
+await User.where({ archived: true }).destroy()
+```
+
+## Complete example
+
+```ts
+import { configureDatabase, Model } from 'mevn-orm'
+
+configureDatabase({
+  client: 'better-sqlite3',
+  connection: { filename: './dev.sqlite' }
+})
+
+class Post extends Model {
+  override fillable = ['user_id', 'title', 'body', 'published']
+  override hidden = []
+}
+
+async function blogDemo() {
+  // Create
+  const post = await Post.create({
+    user_id: 1,
+    title: 'Hello Mevn',
+    body: 'First post',
+    published: true
+  })
+
+  // Read
+  const found = await Post.findOrFail(post.id as number)
+
+  // Update
+  await found.update({ title: 'Hello Mevn ORM' })
+
+  // Query
+  const published = await Post
+    .where({ published: true })
+    .orderBy('id', 'desc')
+    .limit(10)
+    .all()
+
+  console.log(published.toArray())
+
+  // Delete
+  await found.delete()
+}
+```
+
+## Next steps
+
+- [Queries](/guide/queries) — scopes, pagination, counting
+- [Relationships](/guide/relationships)
+- [Serialization](/guide/serialization)

--- a/docs/guide/nuxt.md
+++ b/docs/guide/nuxt.md
@@ -1,0 +1,187 @@
+# Nuxt / Nitro
+
+Initialise Mevn ORM in a Nitro server plugin so every server route shares one configured client. Copy migration files into the build output so production boots can run migrations.
+
+## Why a plugin?
+
+Nitro starts a single server process. A `server/plugins/*.ts` file runs at startup — ideal for `configureDatabase` and optional `migrateLatest`.
+
+## `nuxt.config.ts` — ship migrations
+
+Because Nitro bundles server code, migration **files** must be copied into `.output`:
+
+```ts
+import { cp } from 'node:fs/promises'
+
+export default defineNuxtConfig({
+  nitro: {
+    hooks: {
+      compiled: async () => {
+        await cp(
+          'server/assets/migrations',
+          '.output/server/assets/migrations',
+          { recursive: true }
+        )
+      }
+    }
+  }
+})
+```
+
+Put Knex migrations under `server/assets/migrations/`.
+
+## Server plugin
+
+```ts
+// server/plugins/mevn-orm.ts
+import { defineNitroPlugin } from 'nitropack/runtime'
+import { existsSync } from 'node:fs'
+import {
+  configureDatabase,
+  setMigrationConfig,
+  migrateLatest,
+  migrateRollback
+} from 'mevn-orm'
+
+const isIgnorableMigrationError = (error: unknown): boolean => {
+  const message =
+    error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase()
+
+  return (
+    message.includes('already exists') ||
+    message.includes('duplicate') ||
+    message.includes('does not exist') ||
+    message.includes('no such table') ||
+    message.includes('the migration directory is corrupt')
+  )
+}
+
+export default defineNitroPlugin(async () => {
+  configureDatabase({
+    client: 'pg',
+    connection: process.env.DATABASE_URL
+  })
+
+  // Nitro runtime path differs in dev vs built server.
+  const migrationDirectory = existsSync('./.output/server/assets/migrations')
+    ? './.output/server/assets/migrations'
+    : './server/assets/migrations'
+
+  setMigrationConfig({
+    directory: migrationDirectory,
+    extension: 'ts'
+  })
+
+  // Idempotent at boot: if already migrated, Knex returns empty log.
+  try {
+    await migrateLatest()
+  } catch (error) {
+    if (!isIgnorableMigrationError(error)) throw error
+  }
+
+  // Optional rollback at boot (usually only for dev/preview).
+  if (process.env.NITRO_ROLLBACK_ON_BOOT === 'true') {
+    try {
+      await migrateRollback(undefined, false)
+    } catch (error) {
+      if (!isIgnorableMigrationError(error)) throw error
+    }
+  }
+})
+```
+
+## Models and API routes
+
+```ts
+// server/models/User.ts
+import { Model } from 'mevn-orm'
+
+export class User extends Model {
+  override fillable = ['name', 'email', 'password']
+  override hidden = ['password']
+}
+```
+
+```ts
+// server/api/users/index.get.ts
+import { User } from '../../models/User'
+
+export default defineEventHandler(async (event) => {
+  const query = getQuery(event)
+  const page = Number(query.page ?? 1)
+  const perPage = Number(query.perPage ?? 15)
+
+  const result = await User.orderBy('id', 'desc').paginate(perPage, page)
+
+  return {
+    data: result.data.toArray(),
+    meta: {
+      total: result.total,
+      per_page: result.per_page,
+      current_page: result.current_page,
+      next_page: result.next_page,
+      prev_page: result.prev_page,
+      last_page: result.last_page
+    }
+  }
+})
+```
+
+```ts
+// server/api/users/[id].get.ts
+import { User } from '../../models/User'
+
+export default defineEventHandler(async (event) => {
+  const id = Number(getRouterParam(event, 'id'))
+  const user = await User.find(id)
+
+  if (!user) {
+    throw createError({ statusCode: 404, statusMessage: 'User not found' })
+  }
+
+  return user.toArray()
+})
+```
+
+```ts
+// server/api/users/index.post.ts
+import { User } from '../../models/User'
+// import { hash } from '...' your preferred hasher
+
+export default defineEventHandler(async (event) => {
+  const body = await readBody<{ name: string; email: string; password: string }>(event)
+
+  if (!body?.name || !body?.email || !body?.password) {
+    throw createError({ statusCode: 400, statusMessage: 'Missing fields' })
+  }
+
+  const user = await User.create({
+    name: body.name,
+    email: body.email,
+    password: body.password // hash before create in real apps
+  })
+
+  setResponseStatus(event, 201)
+  return user.toArray()
+})
+```
+
+## Environment
+
+```bash
+DATABASE_URL=postgres://user:pass@localhost:5432/app
+# optional:
+NITRO_ROLLBACK_ON_BOOT=false
+```
+
+## Tips
+
+- Keep models under `server/` so they are not shipped to the client bundle.
+- Prefer connection strings in production (`DATABASE_URL`).
+- For SQLite in local Nuxt dev, use `better-sqlite3` and a file path outside `node_modules`.
+- If migrations fail only in production, confirm the `compiled` hook copied files into `.output/server/assets/migrations`.
+
+## Next steps
+
+- [Migrations](/guide/migrations)
+- [Security](/guide/security)

--- a/docs/guide/queries.md
+++ b/docs/guide/queries.md
@@ -1,0 +1,193 @@
+# Queries
+
+Chain scope methods on the model class, then call a **terminal** method. The scope is reset after each terminal call so queries do not leak into the next operation.
+
+## Anatomy of a query
+
+```ts
+const leads = await Lead
+  .where({ user_id: userId })   // scope
+  .orderBy('created_at', 'desc') // scope
+  .limit(10)                     // scope
+  .all()                         // terminal → ModelCollection
+```
+
+## Scope methods
+
+| Method | Description |
+| --- | --- |
+| `where(conditions)` | Equality conditions passed to Knex `where` |
+| `orderBy(column, direction?)` | Sort (`'asc'` \| `'desc'`, default `'asc'`) |
+| `limit(count)` | Maximum rows |
+| `offset(count)` | Skip rows (often with `limit`) |
+
+```ts
+// Equality object
+await User.where({ email: 'jane@example.com' }).first()
+
+// Compose freely
+await Post
+  .where({ published: true })
+  .orderBy('created_at', 'desc')
+  .offset(20)
+  .limit(10)
+  .all()
+
+// orderBy without a prior where (queries the whole table)
+await Lead.orderBy('created_at', 'desc').all()
+```
+
+## Terminal methods
+
+| Method | Returns |
+| --- | --- |
+| `first(columns?)` | First matching model, or `null` |
+| `all(columns?)` | `ModelCollection` of models |
+| `count(column?)` | Number of matching rows |
+| `paginate(perPage?, page?, columns?)` | Page data + metadata |
+| `update(properties)` | Rows updated (number) |
+| `destroy()` | Rows deleted (number) |
+
+### First and all
+
+```ts
+const user = await User.where({ email: 'jane@example.com' }).first()
+
+const admins = await User.where({ role: 'admin' }).all()
+for (const admin of admins) {
+  console.log(admin.email)
+}
+
+// Column selection
+const slim = await User.all(['id', 'email'])
+```
+
+Without a prior scope, `first()` / `all()` operate on the whole table:
+
+```ts
+const anyone = await User.first()
+const everyone = await User.all()
+```
+
+### Count
+
+```ts
+const total = await User.count()
+const active = await User.where({ active: true }).count()
+```
+
+### Scoped bulk writes
+
+```ts
+const updated = await User
+  .where({ active: false })
+  .update({ archived: true })
+
+const deleted = await Session
+  .where({ expired: true })
+  .destroy()
+```
+
+## Pagination
+
+`paginate()` defaults to **15** items per page on page **1**.
+
+```ts
+const result = await Post.paginate()
+const result10 = await Post.paginate(10)
+const page2 = await Post
+  .where({ published: true })
+  .orderBy('created_at', 'desc')
+  .paginate(10, 2)
+```
+
+### Result shape
+
+```ts
+{
+  data: ModelCollection<Post>, // use .toArray() for plain objects
+  total: number,
+  per_page: number,
+  current_page: number,
+  next_page: number | null,
+  prev_page: number | null,
+  last_page: number,
+}
+```
+
+### API handler example
+
+```ts
+// Express / Nitro style
+export async function listPosts(req: { query: { page?: string; perPage?: string } }) {
+  const page = Number(req.query.page ?? 1)
+  const perPage = Number(req.query.perPage ?? 15)
+
+  const result = await Post
+    .where({ published: true })
+    .orderBy('created_at', 'desc')
+    .paginate(perPage, page)
+
+  return {
+    data: result.data.toArray(),
+    meta: {
+      total: result.total,
+      per_page: result.per_page,
+      current_page: result.current_page,
+      next_page: result.next_page,
+      prev_page: result.prev_page,
+      last_page: result.last_page
+    }
+  }
+}
+```
+
+### Pagination edge cases
+
+- Page numbers are clamped into a valid range (never less than 1, never past `last_page`).
+- Empty tables still return a valid structure with `total: 0` and `last_page: 1`.
+- The scope is reset after `paginate()`, same as other terminals.
+
+## ModelCollection
+
+`all()` and `paginate().data` return a `ModelCollection`, which is an `Array` subclass:
+
+```ts
+const users = await User.all()
+
+users.length
+users.map((u) => u.email)
+users.filter((u) => u.active)
+
+// Plain objects for JSON responses
+return users.toArray()
+```
+
+## Table resolution
+
+Static queries honour `override table` on subclasses:
+
+```ts
+class PasswordReset extends Model {
+  override table = 'password_reset_tokens'
+}
+
+// Uses password_reset_tokens, not password_resets
+await PasswordReset.where({ token }).first()
+
+PasswordReset.currentTable // 'password_reset_tokens'
+PasswordReset.resolveTable() // same
+```
+
+## Query hygiene tips
+
+1. **Always end with a terminal** — scopes alone do not run a query.
+2. **Do not reuse partial chains across awaits** — scope is shared on the class via `currentQuery` and cleared after terminals.
+3. **Prefer scoped updates/deletes** — bare `User.update(...)` / `User.destroy()` affect the whole table.
+4. **Use `toArray()` at the boundary** — keep models inside the service layer; send plain objects to clients.
+
+## Next steps
+
+- [Relationships](/guide/relationships)
+- [Serialization](/guide/serialization)
+- [Raw Knex](/guide/raw-knex) for joins and advanced SQL

--- a/docs/guide/raw-knex.md
+++ b/docs/guide/raw-knex.md
@@ -1,0 +1,119 @@
+# Raw Knex (`DB`)
+
+Mevn ORM is intentionally thin. For joins, transactions, aggregates, or SQL Knex already expresses well, drop down to the shared Knex instance.
+
+## Access
+
+```ts
+import { configureDatabase, DB, getDB } from 'mevn-orm'
+
+configureDatabase({
+  client: 'better-sqlite3',
+  connection: { filename: './dev.sqlite' }
+})
+
+// Preferred: always works after configure
+const knex = getDB()
+const users = await knex('users').select('*')
+
+// Package also exports DB (same underlying client once configured)
+const rows = await getDB()('users').where({ active: true })
+```
+
+`getDB()` throws if you have not called `configure` / `configureDatabase`.
+
+## Joins
+
+```ts
+import { getDB } from 'mevn-orm'
+import { User } from './models/User.js'
+
+const rows = await getDB()('users')
+  .join('posts', 'posts.user_id', 'users.id')
+  .where('posts.published', true)
+  .select('users.id', 'users.email', 'posts.title as post_title')
+
+// Hydrate models when useful
+const userIds = [...new Set(rows.map((r) => r.id))]
+const users = await Promise.all(userIds.map((id) => User.find(id as number)))
+```
+
+## Transactions
+
+```ts
+import { getDB } from 'mevn-orm'
+import { User } from './models/User.js'
+import { Profile } from './models/Profile.js'
+
+await getDB().transaction(async (trx) => {
+  const [userId] = await trx('users').insert({
+    email: 'jane@example.com',
+    name: 'Jane',
+    password: hashed
+  })
+
+  await trx('profiles').insert({
+    user_id: userId,
+    bio: 'Hello'
+  })
+})
+
+// Or mix: use trx for writes, then read via models after commit
+const user = await User.where({ email: 'jane@example.com' }).first()
+```
+
+::: tip Models and transactions
+Static model methods use the global Knex client, not an arbitrary `trx`. For multi-step atomic writes that must share one transaction, prefer raw Knex/`trx` inside `transaction()`, or keep transactional units on one connection yourself.
+:::
+
+## Aggregates and reporting
+
+```ts
+const stats = await getDB()('orders')
+  .select('status')
+  .count('* as total')
+  .sum('amount as revenue')
+  .groupBy('status')
+```
+
+## Batch import
+
+```ts
+const chunkSize = 500
+for (let i = 0; i < rows.length; i += chunkSize) {
+  const chunk = rows.slice(i, i + chunkSize)
+  await getDB()('events').insert(chunk)
+}
+```
+
+## Health check route
+
+```ts
+import { getDB } from 'mevn-orm'
+
+export async function health() {
+  await getDB().raw('select 1')
+  return { ok: true }
+}
+```
+
+## When to stay on Model
+
+Prefer `Model` for:
+
+- Simple CRUD and pagination
+- `fillable` / `hidden` serialization
+- Relationships
+- Type-preserving `find` / `create`
+
+Use raw Knex for:
+
+- Multi-table joins and complex filters
+- Transactions spanning several tables
+- Bulk copy / analytics queries
+- Vendor-specific SQL
+
+## Next steps
+
+- [Queries](/guide/queries)
+- [Configuration](/guide/configuration)

--- a/docs/guide/relationships.md
+++ b/docs/guide/relationships.md
@@ -1,0 +1,213 @@
+# Relationships
+
+Define relationship methods on your models. They return **lazy** relation instances that are Promise-like: you can `await` them directly or chain constraints before they execute.
+
+## Defining relations
+
+```ts
+import { Model } from 'mevn-orm'
+
+class Profile extends Model {
+  override fillable = ['farmer_id', 'bio']
+}
+
+class Farm extends Model {
+  override fillable = ['farmer_id', 'name', 'region', 'active']
+
+  farmer() {
+    return this.belongsTo(Farmer, 'farmer_id')
+  }
+}
+
+class Farmer extends Model {
+  override fillable = ['name', 'email', 'password']
+  override hidden = ['password']
+
+  profile() {
+    return this.hasOne(Profile)
+  }
+
+  farms() {
+    return this.hasMany(Farm)
+  }
+}
+```
+
+## Relationship types
+
+| Method | Cardinality | Default keys |
+| --- | --- | --- |
+| `hasOne(Related, localKey?, foreignKey?)` | One-to-one | `localKey` = parent `id`; `foreignKey` = `{modelName}_id` |
+| `hasMany(Related, localKey?, foreignKey?)` | One-to-many | same defaults |
+| `belongsTo(Related, foreignKey?, ownerKey?)` | Inverse | `foreignKey` required in practice; `ownerKey` defaults to `id` |
+
+### Key defaults
+
+For `Farmer` (`modelName` → `farmer`):
+
+```ts
+// hasOne / hasMany
+this.hasOne(Profile)
+// SELECT * FROM profiles WHERE farmer_id = <this.id>
+
+this.hasMany(Farm)
+// SELECT * FROM farms WHERE farmer_id = <this.id>
+
+// belongsTo on Farm
+this.belongsTo(Farmer, 'farmer_id')
+// SELECT * FROM farmers WHERE id = <this.farmer_id>
+```
+
+### Custom keys
+
+```ts
+class Order extends Model {
+  customer() {
+    return this.belongsTo(Customer, 'customer_uuid', 'uuid')
+  }
+
+  lineItems() {
+    return this.hasMany(LineItem, 'id', 'order_id')
+  }
+}
+```
+
+## Loading relations
+
+### Auto-resolve (await)
+
+```ts
+const farmer = await Farmer.find(1)
+
+const profile = await farmer.profile()  // Profile | null
+const farms = await farmer.farms()      // Farm[]
+```
+
+### Chain then execute
+
+Relation instances support `where()`, `first()`, and `get()`:
+
+```ts
+const farmer = await Farmer.findOrFail(1)
+
+// First matching related row
+const activeFarm = await farmer.farms().where({ active: true }).first()
+
+// All matching related rows
+const westFarms = await farmer.farms().where({ region: 'west' }).get()
+
+// belongsTo / hasOne with filters
+const profile = await farmer.profile().where({ published: true }).first()
+```
+
+### Behaviour by relation type
+
+| Class | `await relation` | Typical use |
+| --- | --- | --- |
+| `HasOneRelation` | single model or `null` | profile, settings |
+| `HasManyRelation` | array of models | posts, farms |
+| `BelongsToRelation` | single model or `null` | author, owner |
+
+## End-to-end example
+
+```ts
+import { configureDatabase, Model } from 'mevn-orm'
+
+configureDatabase({
+  client: 'better-sqlite3',
+  connection: { filename: './dev.sqlite' }
+})
+
+class User extends Model {
+  override fillable = ['email']
+  override hidden = []
+
+  passwordResetToken() {
+    return this.hasOne(PasswordResetToken)
+  }
+
+  posts() {
+    return this.hasMany(Post)
+  }
+}
+
+class PasswordResetToken extends Model {
+  override fillable = ['user_id', 'token']
+
+  user() {
+    return this.belongsTo(User, 'user_id')
+  }
+}
+
+class Post extends Model {
+  override fillable = ['user_id', 'title', 'published']
+
+  author() {
+    return this.belongsTo(User, 'user_id')
+  }
+}
+
+async function demo() {
+  const user = await User.create({ email: 'dev@example.com' })
+
+  await PasswordResetToken.create({
+    user_id: user.id,
+    token: 'abc123'
+  })
+
+  await Post.createMany([
+    { user_id: user.id, title: 'Draft', published: false },
+    { user_id: user.id, title: 'Live', published: true }
+  ])
+
+  const token = await user.passwordResetToken()
+  console.log(token?.token) // 'abc123'
+
+  const published = await user.posts().where({ published: true }).get()
+  console.log(published.map((p) => p.title)) // ['Live']
+
+  const author = await published[0].author()
+  console.log(author?.email) // 'dev@example.com'
+}
+```
+
+## Express route example
+
+```ts
+import { Router } from 'express'
+import { Farmer } from '../models/Farmer.js'
+
+const router = Router()
+
+router.get('/farmers/:id', async (req, res) => {
+  const farmer = await Farmer.find(Number(req.params.id))
+  if (!farmer) {
+    return res.status(404).json({ error: 'Not found' })
+  }
+
+  const [profile, farms] = await Promise.all([
+    farmer.profile(),
+    farmer.farms().where({ active: true }).get()
+  ])
+
+  return res.json({
+    ...farmer.toArray(),
+    profile: profile?.toArray() ?? null,
+    farms: farms.map((f) => f.toArray())
+  })
+})
+
+export default router
+```
+
+## Notes and limitations
+
+- Relations are **not** eager-loaded automatically. Call them when you need related data.
+- Each relation method builds a fresh query; they do not cache results on the parent.
+- For complex joins or multi-table filters, use [raw Knex](/guide/raw-knex) via `getDB()`.
+- Ensure foreign key columns exist in the schema (via [migrations](/guide/migrations)).
+
+## Next steps
+
+- [Serialization](/guide/serialization)
+- [API: Relationships](/api/relationships)

--- a/docs/guide/security.md
+++ b/docs/guide/security.md
@@ -1,0 +1,116 @@
+# Security
+
+Mevn ORM helps with mass-assignment discipline and response hygiene. Application-level security (auth, hashing, validation) remains your responsibility.
+
+## Hash passwords before persist
+
+```ts
+import bcrypt from 'bcrypt'
+import { User } from './models/User.js'
+
+const password = await bcrypt.hash(plainPassword, 12)
+const user = await User.create({
+  name,
+  email,
+  password
+})
+```
+
+Never store plaintext passwords. Serialization (`hidden`) only omits fields from output — it does **not** encrypt or hash.
+
+## Use `hidden` + `toArray()`
+
+```ts
+class User extends Model {
+  override fillable = ['name', 'email', 'password']
+  override hidden = ['password', 'remember_token']
+}
+
+// Good
+res.json((await User.findOrFail(id)).toArray())
+
+// Risky — may include unexpected enumerable fields
+res.json(await User.findOrFail(id))
+```
+
+List every sensitive column in `hidden`: tokens, password hashes, internal flags, PII you must not emit.
+
+## Respect `fillable` on `save()`
+
+Instance `save()` only writes `fillable` keys. That reduces accidental mass assignment when binding request bodies onto a model:
+
+```ts
+const user = new User()
+user.name = body.name
+user.email = body.email
+user.password = hashed
+user.role = body.role // not in fillable → not inserted by save()
+await user.save()
+```
+
+::: warning `create()` vs `save()`
+`Model.create(properties)` inserts the **properties object you pass**, not only `fillable`. Validate and pick allowed keys before calling `create`:
+
+```ts
+const user = await User.create({
+  name: body.name,
+  email: body.email,
+  password: hashed
+  // do not pass body.role unless intentional
+})
+```
+:::
+
+## Validate input
+
+```ts
+function parseCreateUser(body: unknown) {
+  if (!body || typeof body !== 'object') throw new Error('Invalid body')
+  const { name, email, password } = body as Record<string, unknown>
+  if (typeof name !== 'string' || name.length < 1) throw new Error('Invalid name')
+  if (typeof email !== 'string' || !email.includes('@')) throw new Error('Invalid email')
+  if (typeof password !== 'string' || password.length < 8) throw new Error('Invalid password')
+  return { name, email, password }
+}
+```
+
+## Scope destructive queries
+
+```ts
+// Dangerous — entire table
+await User.destroy()
+await User.update({ role: 'admin' })
+
+// Safer
+await User.where({ id: userId }).destroy()
+await User.where({ id: userId }).update({ name: nextName })
+```
+
+## SQL injection
+
+Query methods build parameterised Knex queries for normal object/`where` usage. Avoid concatenating untrusted strings into raw SQL:
+
+```ts
+// Avoid
+await getDB().raw(`select * from users where email = '${email}'`)
+
+// Prefer bindings
+await getDB().raw('select * from users where email = ?', [email])
+```
+
+## Keep dependencies current
+
+- Upgrade `mevn-orm`, `knex`, and database drivers regularly.
+- Run on supported Node.js versions (20+).
+- Review Knex and driver security advisories for your client (`mysql2`, `pg`, `better-sqlite3`, …).
+
+## Checklist
+
+| Practice | Recommendation |
+| --- | --- |
+| Passwords | Hash before `create` / `save` |
+| Secrets in JSON | `hidden` + `toArray()` |
+| Mass assignment | Validate body; careful with `create` |
+| Bulk update/delete | Always `where(...)` first |
+| Raw SQL | Use bindings, never string concat |
+| Migrations in prod | Controlled deploy; avoid auto-rollback |

--- a/docs/guide/serialization.md
+++ b/docs/guide/serialization.md
@@ -1,0 +1,137 @@
+# Serialization
+
+Use `toArray()` when returning data from HTTP handlers so clients receive plain objects without ORM internals or sensitive columns.
+
+## Model `toArray()`
+
+```ts
+class User extends Model {
+  override fillable = ['name', 'email', 'password']
+  override hidden = ['password']
+}
+
+const user = await User.findOrFail(userId)
+return user.toArray()
+// {
+//   id: 1,
+//   name: 'Jane Doe',
+//   email: 'jane@example.com'
+// }
+// password omitted (hidden)
+// fillable, hidden, modelName, table omitted (internals)
+```
+
+### What is excluded
+
+| Category | Keys |
+| --- | --- |
+| ORM internals | `fillable`, `hidden`, `modelName`, `table` |
+| Hidden attributes | whatever you list in `hidden` |
+| Functions | methods on the instance |
+
+## Collection `toArray()`
+
+`Model.all()` and `paginate().data` return a `ModelCollection` with the same helper:
+
+```ts
+const users = await User.all()
+return users.toArray()
+// [{ id: 1, name: '...' }, { id: 2, name: '...' }]
+```
+
+```ts
+const page = await User.orderBy('id').paginate(20, 1)
+
+return {
+  data: page.data.toArray(),
+  meta: {
+    total: page.total,
+    current_page: page.current_page,
+    last_page: page.last_page
+  }
+}
+```
+
+## Hidden fields after reads
+
+After `create`, `find` (via strip paths), and similar operations, **hidden** attributes are also removed from the in-memory instance so accidental logging is less likely. Prefer treating models as internal and always serialising at the edge.
+
+```ts
+const user = await User.create({
+  name: 'Jane',
+  email: 'jane@example.com',
+  password: hashed
+})
+
+// password may already be stripped from the instance
+console.log(user.toArray()) // never includes password
+```
+
+## Nesting related data
+
+Relations return models (or arrays). Map them yourself:
+
+```ts
+const farmer = await Farmer.findOrFail(id)
+const farms = await farmer.farms().get()
+
+return {
+  ...farmer.toArray(),
+  farms: farms.map((f) => f.toArray())
+}
+```
+
+## API response helpers
+
+```ts
+// utils/respond.ts
+import type { Model, ModelCollection } from 'mevn-orm'
+
+export function jsonModel(model: Model) {
+  return model.toArray()
+}
+
+export function jsonCollection(models: ModelCollection<Model> | Model[]) {
+  if ('toArray' in models && typeof models.toArray === 'function') {
+    return models.toArray()
+  }
+  return models.map((m) => m.toArray())
+}
+
+export function jsonPage<T extends Model>(result: {
+  data: ModelCollection<T>
+  total: number
+  per_page: number
+  current_page: number
+  next_page: number | null
+  prev_page: number | null
+  last_page: number
+}) {
+  return {
+    data: result.data.toArray(),
+    meta: {
+      total: result.total,
+      per_page: result.per_page,
+      current_page: result.current_page,
+      next_page: result.next_page,
+      prev_page: result.prev_page,
+      last_page: result.last_page
+    }
+  }
+}
+```
+
+Usage:
+
+```ts
+const page = await Post.where({ published: true }).paginate(10, 2)
+return jsonPage(page)
+```
+
+## Security checklist
+
+- Put secrets (`password`, `token`, `ssn`) in `hidden`.
+- Never spread a model into `res.json(user)` if you have not verified hidden fields — use `toArray()`.
+- Hash passwords **before** `create` / `save`; serialization only hides, it does not hash.
+
+See also [Security](/guide/security).

--- a/docs/guide/what-is-mevn-orm.md
+++ b/docs/guide/what-is-mevn-orm.md
@@ -1,0 +1,51 @@
+# What is Mevn ORM?
+
+Mevn ORM is a small **ActiveRecord-style** ORM for Node.js, built on top of [Knex](https://knexjs.org/). It is designed for Express, Nuxt/Nitro, and other ESM apps that want model classes and a simple query API without the surface area of larger frameworks.
+
+## Design goals
+
+- **Thin layer over Knex** — configuration and queries map cleanly to Knex concepts.
+- **ActiveRecord feel** — models own their table, CRUD methods, and relationships.
+- **TypeScript-first** — static methods preserve derived class types (`User.find()` returns `User | null`).
+- **Small API** — enough for everyday CRUD, pagination, and relations; escape hatch via `DB` when you need raw SQL.
+
+## What it exports
+
+| Export | Role |
+| --- | --- |
+| `Model` | Base class for your tables |
+| `ModelCollection` | Array subclass from `all()` / `paginate()`, with `toArray()` |
+| `configureDatabase` / `configure` | Database initialisation |
+| `HasOneRelation`, `HasManyRelation`, `BelongsToRelation` | Relationship wrappers |
+| Migration helpers | `makeMigration`, `migrateLatest`, `migrateRollback`, … |
+| `DB` / `getDB()` | Active Knex instance |
+
+## Status
+
+The project is in **maintenance mode**. Core functionality is stable and actively maintained; large new features are limited.
+
+## Requirements
+
+- **Node.js 20+** (ESM runtime)
+- **Knex** as a peer dependency
+- A database driver for your client (`mysql2`, `pg`, `better-sqlite3`, etc.)
+
+## When to use it
+
+**Good fit when you want:**
+
+- Lightweight models over Knex in an Express or Nuxt backend
+- Familiar ActiveRecord patterns (`User.create`, `user.update`, `hasMany`)
+- Programmatic migrations without a heavyweight schema DSL
+
+**Consider alternatives when you need:**
+
+- Full graph loading / N+1 prevention strategies
+- Complex multi-tenant schema tooling
+- Database-agnostic query builders beyond what Knex already provides
+
+## Next steps
+
+- [Getting Started](/guide/getting-started) — install, configure, first model
+- [Configuration](/guide/configuration) — clients, connection styles, advanced Knex config
+- [API Overview](/api/) — full export reference

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,32 @@
+---
+layout: home
+
+hero:
+  name: Mevn ORM
+  text: ActiveRecord for Node.js
+  tagline: A small, focused ORM built on Knex. Define models, query with a fluent API, and ship Express or Nuxt apps without the bulk of larger ORMs.
+  actions:
+    - theme: brand
+      text: Get Started
+      link: /guide/getting-started
+    - theme: alt
+      text: API Reference
+      link: /api/
+    - theme: alt
+      text: GitHub
+      link: https://github.com/StanleyMasinde/mevn-orm
+
+features:
+  - title: ActiveRecord models
+    details: Extend Model, set fillable and hidden fields, and use create, find, update, and delete with TypeScript-friendly return types.
+  - title: Fluent queries
+    details: Chain where, orderBy, limit, and offset, then finish with first, all, count, or paginate. Scopes reset after each terminal call.
+  - title: Relationships
+    details: hasOne, hasMany, and belongsTo return lazy Promise-like relations you can await directly or chain with where before loading.
+  - title: Knex under the hood
+    details: Use MySQL, Postgres, SQLite, MSSQL, or Oracle. Drop down to the raw Knex instance whenever you need full SQL control.
+  - title: Migrations included
+    details: Programmatic makeMigration, migrateLatest, and migrateRollback helpers, plus npm scripts for day-to-day schema work.
+  - title: API-ready serialization
+    details: toArray on models and collections strips hidden attributes and ORM internals so responses stay clean.
+---

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "orm-express",
     "orm-mysql"
   ],
-  "homepage": "https://github.com/StanleyMasinde/mevn-orm#readme",
+  "homepage": "https://stanleymasinde.github.io/mevn-orm/",
   "bugs": {
     "url": "https://github.com/StanleyMasinde/mevn-orm/issues",
     "email": "stanleymasinde1@gmail.com"
@@ -58,7 +58,10 @@
     "migrate:version": "node --import tsx scripts/migrate.ts version",
     "lint": "eslint .",
     "build": "tsc -p tsconfig.build.json",
-    "prepack": "pnpm run build"
+    "prepack": "pnpm run build",
+    "docs:dev": "vitepress dev docs",
+    "docs:build": "vitepress build docs",
+    "docs:preview": "vitepress preview docs"
   },
   "dependencies": {
     "pluralize": "^8.0.0"
@@ -76,6 +79,7 @@
     "typescript": "^7.0.2",
     "typescript-eslint": "^8.65.0",
     "vite": "^8.1.5",
+    "vitepress": "^1.6.4",
     "vitest": "^4.1.10"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,11 +51,130 @@ importers:
       vite:
         specifier: ^8.1.5
         version: 8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(tsx@4.23.1)
+      vitepress:
+        specifier: ^1.6.4
+        version: 1.6.4(@algolia/client-search@5.56.0)(@types/node@25.9.5)(lightningcss@1.33.0)(postcss@8.5.22)(search-insights@2.17.3)(typescript@7.0.2)
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@types/node@25.9.5)(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(tsx@4.23.1))
 
 packages:
+
+  '@algolia/abtesting@1.22.0':
+    resolution: {integrity: sha512-BFR6zNowNKcY7Ou7TaJc9QWexES4YKPbmf/OTFofpdsdhz4x6q0lbxp3duO0EHnyrN7rE4ba/TSXuY+BDGu4+g==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/autocomplete-core@1.17.7':
+    resolution: {integrity: sha512-BjiPOW6ks90UKl7TwMv7oNQMnzU+t/wk9mgIDi6b1tXpUek7MW0lbNOUHpvam9pe3lVCf4xPFT+lK7s+e+fs7Q==}
+
+  '@algolia/autocomplete-plugin-algolia-insights@1.17.7':
+    resolution: {integrity: sha512-Jca5Ude6yUOuyzjnz57og7Et3aXjbwCSDf/8onLHSQgw1qW3ALl9mrMWaXb5FmPVkV3EtkD2F/+NkT6VHyPu9A==}
+    peerDependencies:
+      search-insights: '>= 1 < 3'
+
+  '@algolia/autocomplete-preset-algolia@1.17.7':
+    resolution: {integrity: sha512-ggOQ950+nwbWROq2MOCIL71RE0DdQZsceqrg32UqnhDz8FlO9rL8ONHNsI2R1MH0tkgVIDKI/D0sMiUchsFdWA==}
+    peerDependencies:
+      '@algolia/client-search': '>= 4.9.1 < 6'
+      algoliasearch: '>= 4.9.1 < 6'
+
+  '@algolia/autocomplete-shared@1.17.7':
+    resolution: {integrity: sha512-o/1Vurr42U/qskRSuhBH+VKxMvkkUVTLU6WZQr+L5lGZZLYWyhdzWjW0iGXY7EkwRTjBqvN2EsR81yCTGV/kmg==}
+    peerDependencies:
+      '@algolia/client-search': '>= 4.9.1 < 6'
+      algoliasearch: '>= 4.9.1 < 6'
+
+  '@algolia/client-abtesting@5.56.0':
+    resolution: {integrity: sha512-7r4Z3NC7yU1oAQVWJNA2HX7tX481F3pJvCGyLIXiTdBcthz4Q/o21jwcMYDFkuI92UWTNBQQmHYgwHo1zS5dzg==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/client-analytics@5.56.0':
+    resolution: {integrity: sha512-avmjXQSq+jadFO8Xl2em05/uQdQnEmHsJyOAdVbZkmVgpMfxL12aJwVVfGNwYr9nulcpuJN1X0lTaQ5wxuNGcA==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/client-common@5.56.0':
+    resolution: {integrity: sha512-v2TPStUhY//ripPjIVclZ8AWc7DEGooXULZGFlFu37zNatgHjw34oZZ+OSbbc/YHO+xZwPl62I1k8xH1m4S2eg==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/client-insights@5.56.0':
+    resolution: {integrity: sha512-P0ehROpM4Sem3Sqo5x2cKPgj67D3G3jy0rh1Amwkcvsfr6tkvIcdCmerieanqTF7NxUMPNFLkpIFeMO8Rpa50w==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/client-personalization@5.56.0':
+    resolution: {integrity: sha512-SXK3Vn3WVxyzbm31oePZBJkp1wpOyuWdd4B/Pv7n0aXDxmeSWhC1R1FC1517mMrFAIaPH4Rt0x6RUe7ZNjz8FA==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/client-query-suggestions@5.56.0':
+    resolution: {integrity: sha512-5+ZdX8garFnmycnZgKhtXHePEaLj5zqDxI/0lkhhluzCcvTn0/PvvTirTg8hHYetQHvn7GDyeAiqTAieMvMW4A==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/client-search@5.56.0':
+    resolution: {integrity: sha512-+mKUdYvqOi0BcvpAEyCEw49vSBptufIcfibtHz2bdr1pI789M46Yt0uQEk/sxtK3teh71OQvVFHaTDzShUWewQ==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/ingestion@1.56.0':
+    resolution: {integrity: sha512-9g/zj+AZx5moFcdFIrYQoVrueXivjUcc3MQHtCYT8WhIuk1lUh1AyEhvJCS0XBZld09cLvd1AZ3BvDBpVpX2UA==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/monitoring@1.56.0':
+    resolution: {integrity: sha512-Qf3Sr6f9A9uxCZUf3MXS0d2b877uYzEB5yxqpVGXAhcJnBCQjrRRon0KvefpGkxy+BshrIJs96OUoMtGqXTFDA==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/recommend@5.56.0':
+    resolution: {integrity: sha512-GXWG1rWc5wu8hY4N33Y3b6ernY6sAdAvmKWN/zHAiACOx40WnpG0TVX5YazCAr/9gOYGInSiM2A0y2jy2xbiDA==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/requester-browser-xhr@5.56.0':
+    resolution: {integrity: sha512-7t24cBxaInS3mZb7ddEaZT/tp6q+/aR4YttsQVyP1/i+LmwPR34atO35KjaLFCcRVrlP7sYOAqkCfg6lIRB+ew==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/requester-fetch@5.56.0':
+    resolution: {integrity: sha512-R7ePHgVYmDFjZpvrsVAfbDz/d4RxKAYZ5/vgLfIsCVRZRryjWl/3INOxpOICzitehQ5FjNtNjcLQTrmHPTcHBQ==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/requester-node-http@5.56.0':
+    resolution: {integrity: sha512-PIOUXlSnrqM0S+WOgDRb4RzotydJH7ZoT6tOyL7tAO7qJOfvX5wsEW8Pe+PMKMwvuI4/gIyK9cg2H7lJXqnc4Q==}
+    engines: {node: '>= 14.0.0'}
+
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
+    engines: {node: '>=6.9.0'}
+
+  '@docsearch/css@3.8.2':
+    resolution: {integrity: sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ==}
+
+  '@docsearch/js@3.8.2':
+    resolution: {integrity: sha512-Q5wY66qHn0SwA7Taa0aDbHiJvaFJLOJyHmooQ7y8hlwwQLQ/5WwCcoX0g7ii04Qi2DJlHsd0XXzJ8Ypw9+9YmQ==}
+
+  '@docsearch/react@3.8.2':
+    resolution: {integrity: sha512-xCRrJQlTt8N9GU0DG4ptwHRkfnSnD/YpdeaXe02iKfqs97TkZJv60yE+1eq/tjPcVnTW8dP5qLP7itifFVV5eg==}
+    peerDependencies:
+      '@types/react': '>= 16.8.0 < 19.0.0'
+      react: '>= 16.8.0 < 19.0.0'
+      react-dom: '>= 16.8.0 < 19.0.0'
+      search-insights: '>= 1 < 3'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+      search-insights:
+        optional: true
 
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
@@ -66,16 +185,34 @@ packages:
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.28.1':
     resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.28.1':
     resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.28.1':
@@ -84,16 +221,34 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.28.1':
     resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.28.1':
     resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.28.1':
@@ -102,10 +257,22 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.28.1':
     resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.28.1':
@@ -114,10 +281,22 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.28.1':
     resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.28.1':
@@ -126,10 +305,22 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.28.1':
     resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.28.1':
@@ -138,10 +329,22 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.28.1':
     resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.28.1':
@@ -150,16 +353,34 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.28.1':
     resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.28.1':
     resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
     engines: {node: '>=18'}
     cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [linux]
 
   '@esbuild/linux-x64@0.28.1':
@@ -174,6 +395,12 @@ packages:
     cpu: [arm64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.28.1':
     resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
     engines: {node: '>=18'}
@@ -184,6 +411,12 @@ packages:
     resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.28.1':
@@ -198,11 +431,23 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/sunos-x64@0.28.1':
     resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
+
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
 
   '@esbuild/win32-arm64@0.28.1':
     resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
@@ -210,10 +455,22 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.28.1':
     resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.28.1':
@@ -284,6 +541,12 @@ packages:
   '@humanwhocodes/retry@0.4.3':
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
+
+  '@iconify-json/simple-icons@1.2.91':
+    resolution: {integrity: sha512-plQJHZxzpkIXaeYjJF0Sc9nkzYF32EDX9olx7j1hcKYFaiTrQXbcngZmvzuV0pG6uZPU3ZuA/GIsgxSHOm6jrQ==}
+
+  '@iconify/types@2.0.0':
+    resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
 
   '@isaacs/fs-minipass@4.0.1':
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
@@ -399,6 +662,168 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
+  '@rollup/rollup-android-arm-eabi@4.62.2':
+    resolution: {integrity: sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.62.2':
+    resolution: {integrity: sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.62.2':
+    resolution: {integrity: sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.62.2':
+    resolution: {integrity: sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.62.2':
+    resolution: {integrity: sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.62.2':
+    resolution: {integrity: sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
+    resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.2':
+    resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.2':
+    resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.62.2':
+    resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.2':
+    resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.62.2':
+    resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.2':
+    resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.2':
+    resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.2':
+    resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.2':
+    resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.2':
+    resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.62.2':
+    resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.62.2':
+    resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.62.2':
+    resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.62.2':
+    resolution: {integrity: sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.2':
+    resolution: {integrity: sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.2':
+    resolution: {integrity: sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.62.2':
+    resolution: {integrity: sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.62.2':
+    resolution: {integrity: sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@shikijs/core@2.5.0':
+    resolution: {integrity: sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg==}
+
+  '@shikijs/engine-javascript@2.5.0':
+    resolution: {integrity: sha512-VjnOpnQf8WuCEZtNUdjjwGUbtAVKuZkVQ/5cHy/tojVVRIRtlWMYVjyWhxOmIq05AlSOv72z7hRNRGVBgQOl0w==}
+
+  '@shikijs/engine-oniguruma@2.5.0':
+    resolution: {integrity: sha512-pGd1wRATzbo/uatrCIILlAdFVKdxImWJGQ5rFiB5VZi2ve5xj3Ax9jny8QvkaV93btQEwR/rSz5ERFpC5mKNIw==}
+
+  '@shikijs/langs@2.5.0':
+    resolution: {integrity: sha512-Qfrrt5OsNH5R+5tJ/3uYBBZv3SuGmnRPejV9IlIbFH3HTGLDlkqgHymAlzklVmKBjAaVmkPkyikAV/sQ1wSL+w==}
+
+  '@shikijs/themes@2.5.0':
+    resolution: {integrity: sha512-wGrk+R8tJnO0VMzmUExHR+QdSaPUl/NKs+a4cQQRWyoc3YFbUzuLEi/KWK1hj+8BfHRKm2jNhhJck1dfstJpiw==}
+
+  '@shikijs/transformers@2.5.0':
+    resolution: {integrity: sha512-SI494W5X60CaUwgi8u4q4m4s3YAFSxln3tzNjOSYqq54wlVgz0/NbbXEb3mdLbqMBztcmS7bVTaEd2w0qMmfeg==}
+
+  '@shikijs/types@2.5.0':
+    resolution: {integrity: sha512-ygl5yhxki9ZLNuNpPitBWvcy9fsSKKaRuO4BAlMyagszQidxcpLAr0qiW/q43DtSIDxO6hEbtYLiFZNXO/hdGw==}
+
+  '@shikijs/vscode-textmate@10.0.2':
+    resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -417,11 +842,32 @@ packages:
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
+  '@types/hast@3.0.5':
+    resolution: {integrity: sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
+  '@types/linkify-it@5.0.0':
+    resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
+
+  '@types/markdown-it@14.1.2':
+    resolution: {integrity: sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/mdurl@2.0.0':
+    resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
+
   '@types/node@25.9.5':
     resolution: {integrity: sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@types/web-bluetooth@0.0.21':
+    resolution: {integrity: sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==}
 
   '@typescript-eslint/eslint-plugin@8.65.0':
     resolution: {integrity: sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==}
@@ -602,6 +1048,16 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@ungap/structured-clone@1.3.3':
+    resolution: {integrity: sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==}
+
+  '@vitejs/plugin-vue@5.2.4':
+    resolution: {integrity: sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    peerDependencies:
+      vite: ^5.0.0 || ^6.0.0
+      vue: ^3.2.25
+
   '@vitest/expect@4.1.10':
     resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
 
@@ -631,6 +1087,92 @@ packages:
   '@vitest/utils@4.1.10':
     resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
 
+  '@vue/compiler-core@3.5.40':
+    resolution: {integrity: sha512-39E8IgOhTbVDnoJFMKc2DvYnypcZwUqgUhQkccva/0m6FUwtIKSGV7n1hpVmYcFaoRAwf9pBcwnKlCEsN63ZEQ==}
+
+  '@vue/compiler-dom@3.5.40':
+    resolution: {integrity: sha512-pwkx4vqlqOspFstrcmzwkKLePVMD3PT65imRzLhanU2V1Fj4K13g6OXjanOyzw3aTAuRk84BOmY8f3rEHqPaVA==}
+
+  '@vue/compiler-sfc@3.5.40':
+    resolution: {integrity: sha512-gIf497P4kpuALcvs5n3AEg1Vdn0pSY4XbjASIfHNYF1/MP3T2Mf2STERTubysBxCRxzJGJYtF/O7vwJrxFB3Vw==}
+
+  '@vue/compiler-ssr@3.5.40':
+    resolution: {integrity: sha512-rrE5xiXG663+vHCHa3J9p2z5OcBRjXmoqenprJxAFQxg5pSshzeBiCE6pu46axapRJ2Adk0YDA2BRZVjiHXnhg==}
+
+  '@vue/devtools-api@7.7.10':
+    resolution: {integrity: sha512-KxtEpUOOpFz/qOGRrAwA36QF7DqIA+FXgCYit9mk9wjbaZt0sXOFz81ElOZtKA4HbWHUdwNjZHBFsFFyp5BZiA==}
+
+  '@vue/devtools-kit@7.7.10':
+    resolution: {integrity: sha512-3WNi2Kq4tbpVbmhml7RiphmAt0279oh3fKNeWMQIrltfX8Q91b4i5PL8DtyNKdwmcsGrV4fg+erwWOmD05CLIw==}
+
+  '@vue/devtools-shared@7.7.10':
+    resolution: {integrity: sha512-wOPslzB8vTvpxwdaOcR2qAbwmuSP0L+rhpoC6Cf56V3Jip+HWb7PQQXOUPgBNQARpXsbQX/+mvi8kKucmBGRwQ==}
+
+  '@vue/reactivity@3.5.40':
+    resolution: {integrity: sha512-B7ot9UlUZOi1zbq61/LvE88ZLTV8IlajTdiZTAEiDQgrnIMIZoPr9kGw0Zw46ObW62O9+H/Be3kMbfb7kYPQZA==}
+
+  '@vue/runtime-core@3.5.40':
+    resolution: {integrity: sha512-KAZLweuZ6uUJPK1PMSQPgBU5gCjgrrfjUhSglmU9NhH+Zjepa8cnwSydPWDWHDwOgY4g3VcZ+PljbiHlURNCbw==}
+
+  '@vue/runtime-dom@3.5.40':
+    resolution: {integrity: sha512-ZfrX8ssZQds900L9pr8AuK05ddnMsR4MPMZr8cPN9GoqoPWcXLhjvvbIA2SMv+7a97sJ1vv9pj/zxK0Cq/eEFQ==}
+
+  '@vue/server-renderer@3.5.40':
+    resolution: {integrity: sha512-XNJym9WpevhTVt1HuwOrCRJ5Q+9z4BjTMrDtjTrvx74SmUll8spNTw6whWJa9mEkO4PKn5TihI/bm/8ds2QVJw==}
+
+  '@vue/shared@3.5.40':
+    resolution: {integrity: sha512-WxnBtruIqOoV3rA4jeKDWzrYI5h7Cp4+pjwDi8kWGHz+IslhiN+wguLVVhtv2l8VoU02rzDCVfDjgCl1lNpZVg==}
+
+  '@vueuse/core@12.8.2':
+    resolution: {integrity: sha512-HbvCmZdzAu3VGi/pWYm5Ut+Kd9mn1ZHnn4L5G8kOQTPs/IwIAmJoBrmYk2ckLArgMXZj0AW3n5CAejLUO+PhdQ==}
+
+  '@vueuse/integrations@12.8.2':
+    resolution: {integrity: sha512-fbGYivgK5uBTRt7p5F3zy6VrETlV9RtZjBqd1/HxGdjdckBgBM4ugP8LHpjolqTj14TXTxSK1ZfgPbHYyGuH7g==}
+    peerDependencies:
+      async-validator: ^4
+      axios: ^1
+      change-case: ^5
+      drauu: ^0.4
+      focus-trap: ^7
+      fuse.js: ^7
+      idb-keyval: ^6
+      jwt-decode: ^4
+      nprogress: ^0.2
+      qrcode: ^1.5
+      sortablejs: ^1
+      universal-cookie: ^7
+    peerDependenciesMeta:
+      async-validator:
+        optional: true
+      axios:
+        optional: true
+      change-case:
+        optional: true
+      drauu:
+        optional: true
+      focus-trap:
+        optional: true
+      fuse.js:
+        optional: true
+      idb-keyval:
+        optional: true
+      jwt-decode:
+        optional: true
+      nprogress:
+        optional: true
+      qrcode:
+        optional: true
+      sortablejs:
+        optional: true
+      universal-cookie:
+        optional: true
+
+  '@vueuse/metadata@12.8.2':
+    resolution: {integrity: sha512-rAyLGEuoBJ/Il5AmFHiziCPdQzRt88VxR+Y/A/QhJ1EWtWqPBBAxTAFaSkviwEuOEZNtW8pvkPgoCZQ+HxqW1A==}
+
+  '@vueuse/shared@12.8.2':
+    resolution: {integrity: sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w==}
+
   abbrev@4.0.0:
     resolution: {integrity: sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==}
     engines: {node: ^20.17.0 || >=22.9.0}
@@ -647,6 +1189,10 @@ packages:
 
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
+
+  algoliasearch@5.56.0:
+    resolution: {integrity: sha512-PrqppUmhT4ENdas2pH9caE7efUcxy6EcSFhWzosiVuQBzu2tQ5yLTI6jwomT/1cuBnivzGfxiJCqDNN9FRRh+Q==}
+    engines: {node: '>= 14.0.0'}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -670,6 +1216,9 @@ packages:
   bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
 
+  birpc@2.9.0:
+    resolution: {integrity: sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==}
+
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
@@ -680,9 +1229,18 @@ packages:
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
 
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
@@ -694,6 +1252,9 @@ packages:
   colorette@2.0.19:
     resolution: {integrity: sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==}
 
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
+
   commander@10.0.1:
     resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
     engines: {node: '>=14'}
@@ -701,9 +1262,16 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  copy-anything@4.0.5:
+    resolution: {integrity: sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==}
+    engines: {node: '>=18'}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   debug@4.3.4:
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
@@ -738,16 +1306,30 @@ packages:
     resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
     engines: {node: '>=0.10'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
   dotenv@17.4.2:
     resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
     engines: {node: '>=12'}
 
+  emoji-regex-xs@1.0.0:
+    resolution: {integrity: sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==}
+
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
 
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
@@ -759,6 +1341,11 @@ packages:
 
   es-module-lexer@2.3.1:
     resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
+
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
 
   esbuild@0.28.1:
     resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
@@ -815,6 +1402,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
@@ -869,6 +1459,9 @@ packages:
   flatted@3.4.3:
     resolution: {integrity: sha512-/zipXxyO6rGvuNGDiULY9MvEGSkb2gaG4GGH4ygMi0ZZzyMHdUZBmntJmx5x1G2VuPytCwGN4xsJP6cw+sK+vQ==}
 
+  focus-trap@7.8.0:
+    resolution: {integrity: sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==}
+
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
@@ -903,6 +1496,18 @@ packages:
   hasown@2.0.4:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
+
+  hast-util-to-html@9.0.5:
+    resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
+  hookable@5.5.3:
+    resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
+
+  html-void-elements@3.0.0:
+    resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
   iconv-lite@0.7.3:
     resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
@@ -947,6 +1552,10 @@ packages:
 
   is-property@1.0.2:
     resolution: {integrity: sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==}
+
+  is-what@5.5.0:
+    resolution: {integrity: sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==}
+    engines: {node: '>=18'}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -1096,6 +1705,27 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  mark.js@8.11.1:
+    resolution: {integrity: sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==}
+
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
@@ -1111,9 +1741,15 @@ packages:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  minisearch@7.2.0:
+    resolution: {integrity: sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==}
+
   minizlib@3.1.0:
     resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
     engines: {node: '>= 18'}
+
+  mitt@3.0.1:
+    resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
 
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
@@ -1170,6 +1806,9 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
+  oniguruma-to-es@3.1.1:
+    resolution: {integrity: sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ==}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -1196,6 +1835,9 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
+  perfect-debounce@1.0.0:
+    resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
+
   pg-connection-string@2.6.2:
     resolution: {integrity: sha512-ch6OwaeaPYcova4kKZ15sbJ2hKb/VP48ZD2gE7i1J+L4MspCtBMAx8nMgz7bksc7IojCIIWuEhHibSMFH8m8oA==}
 
@@ -1214,6 +1856,14 @@ packages:
     resolution: {integrity: sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==}
     engines: {node: ^10 || ^12 || >=14}
 
+  preact@10.29.7:
+    resolution: {integrity: sha512-DCHYrK/B10yUD3ZjLfhZ3WIE/9Vf9VFUODcRE2dRomTYDpJk6z6L9wecSfhfE6M9ZTHUdyQkoC46arIDhEV84Q==}
+    peerDependencies:
+      preact-render-to-string: '>=5'
+    peerDependenciesMeta:
+      preact-render-to-string:
+        optional: true
+
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
     engines: {node: '>=10'}
@@ -1227,6 +1877,9 @@ packages:
   proc-log@6.1.0:
     resolution: {integrity: sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==}
     engines: {node: ^20.17.0 || >=22.9.0}
+
+  property-information@7.2.0:
+    resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
 
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
@@ -1247,6 +1900,15 @@ packages:
     resolution: {integrity: sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==}
     engines: {node: '>= 10.13.0'}
 
+  regex-recursion@6.0.2:
+    resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
+
+  regex-utilities@2.3.0:
+    resolution: {integrity: sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==}
+
+  regex@6.1.0:
+    resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
+
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
@@ -1256,9 +1918,17 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
+  rfdc@1.4.1:
+    resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
+
   rolldown@1.1.5:
     resolution: {integrity: sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==}
     engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  rollup@4.62.2:
+    resolution: {integrity: sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
   safe-buffer@5.2.1:
@@ -1266,6 +1936,9 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  search-insights@2.17.3:
+    resolution: {integrity: sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==}
 
   semver@7.8.5:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
@@ -1280,6 +1953,9 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  shiki@2.5.0:
+    resolution: {integrity: sha512-mI//trrsaiCIPsja5CNfsyNOqgAZUb6VpJA+340toL42UpzQlXpwRV9nch69X6gaUxrr9kaOOa6e3y3uAkGFxQ==}
+
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
@@ -1291,6 +1967,13 @@ packages:
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
+  speakingurl@14.0.1:
+    resolution: {integrity: sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==}
     engines: {node: '>=0.10.0'}
 
   sql-escaper@1.5.1:
@@ -1310,13 +1993,23 @@ packages:
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
     engines: {node: '>=0.10.0'}
 
+  superjson@2.2.6:
+    resolution: {integrity: sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==}
+    engines: {node: '>=16'}
+
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  tabbable@6.5.0:
+    resolution: {integrity: sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==}
 
   tar-fs@2.1.5:
     resolution: {integrity: sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==}
@@ -1351,6 +2044,9 @@ packages:
   tinyrainbow@3.1.0:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
+
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
 
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
@@ -1392,11 +2088,63 @@ packages:
     resolution: {integrity: sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==}
     engines: {node: '>=18.17'}
 
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
 
   vite@8.1.5:
     resolution: {integrity: sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==}
@@ -1441,6 +2189,18 @@ packages:
       yaml:
         optional: true
 
+  vitepress@1.6.4:
+    resolution: {integrity: sha512-+2ym1/+0VVrbhNyRoFFesVvBvHAVMZMK0rw60E3X/5349M1GuVdKeazuksqopEdvkKwKGs21Q729jX81/bkBJg==}
+    hasBin: true
+    peerDependencies:
+      markdown-it-mathjax3: ^4
+      postcss: ^8
+    peerDependenciesMeta:
+      markdown-it-mathjax3:
+        optional: true
+      postcss:
+        optional: true
+
   vitest@4.1.10:
     resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -1482,6 +2242,14 @@ packages:
       jsdom:
         optional: true
 
+  vue@3.5.40:
+    resolution: {integrity: sha512-+8PJ4SJXdn/cHGImF4CKdxlWHIN5Dkt7DoufRREM6h6uVCx2m7QxgcEQmmzyOK8A9mcafg7sFbJFYsdFVubTig==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -1512,7 +2280,160 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
+
 snapshots:
+
+  '@algolia/abtesting@1.22.0':
+    dependencies:
+      '@algolia/client-common': 5.56.0
+      '@algolia/requester-browser-xhr': 5.56.0
+      '@algolia/requester-fetch': 5.56.0
+      '@algolia/requester-node-http': 5.56.0
+
+  '@algolia/autocomplete-core@1.17.7(@algolia/client-search@5.56.0)(algoliasearch@5.56.0)(search-insights@2.17.3)':
+    dependencies:
+      '@algolia/autocomplete-plugin-algolia-insights': 1.17.7(@algolia/client-search@5.56.0)(algoliasearch@5.56.0)(search-insights@2.17.3)
+      '@algolia/autocomplete-shared': 1.17.7(@algolia/client-search@5.56.0)(algoliasearch@5.56.0)
+    transitivePeerDependencies:
+      - '@algolia/client-search'
+      - algoliasearch
+      - search-insights
+
+  '@algolia/autocomplete-plugin-algolia-insights@1.17.7(@algolia/client-search@5.56.0)(algoliasearch@5.56.0)(search-insights@2.17.3)':
+    dependencies:
+      '@algolia/autocomplete-shared': 1.17.7(@algolia/client-search@5.56.0)(algoliasearch@5.56.0)
+      search-insights: 2.17.3
+    transitivePeerDependencies:
+      - '@algolia/client-search'
+      - algoliasearch
+
+  '@algolia/autocomplete-preset-algolia@1.17.7(@algolia/client-search@5.56.0)(algoliasearch@5.56.0)':
+    dependencies:
+      '@algolia/autocomplete-shared': 1.17.7(@algolia/client-search@5.56.0)(algoliasearch@5.56.0)
+      '@algolia/client-search': 5.56.0
+      algoliasearch: 5.56.0
+
+  '@algolia/autocomplete-shared@1.17.7(@algolia/client-search@5.56.0)(algoliasearch@5.56.0)':
+    dependencies:
+      '@algolia/client-search': 5.56.0
+      algoliasearch: 5.56.0
+
+  '@algolia/client-abtesting@5.56.0':
+    dependencies:
+      '@algolia/client-common': 5.56.0
+      '@algolia/requester-browser-xhr': 5.56.0
+      '@algolia/requester-fetch': 5.56.0
+      '@algolia/requester-node-http': 5.56.0
+
+  '@algolia/client-analytics@5.56.0':
+    dependencies:
+      '@algolia/client-common': 5.56.0
+      '@algolia/requester-browser-xhr': 5.56.0
+      '@algolia/requester-fetch': 5.56.0
+      '@algolia/requester-node-http': 5.56.0
+
+  '@algolia/client-common@5.56.0': {}
+
+  '@algolia/client-insights@5.56.0':
+    dependencies:
+      '@algolia/client-common': 5.56.0
+      '@algolia/requester-browser-xhr': 5.56.0
+      '@algolia/requester-fetch': 5.56.0
+      '@algolia/requester-node-http': 5.56.0
+
+  '@algolia/client-personalization@5.56.0':
+    dependencies:
+      '@algolia/client-common': 5.56.0
+      '@algolia/requester-browser-xhr': 5.56.0
+      '@algolia/requester-fetch': 5.56.0
+      '@algolia/requester-node-http': 5.56.0
+
+  '@algolia/client-query-suggestions@5.56.0':
+    dependencies:
+      '@algolia/client-common': 5.56.0
+      '@algolia/requester-browser-xhr': 5.56.0
+      '@algolia/requester-fetch': 5.56.0
+      '@algolia/requester-node-http': 5.56.0
+
+  '@algolia/client-search@5.56.0':
+    dependencies:
+      '@algolia/client-common': 5.56.0
+      '@algolia/requester-browser-xhr': 5.56.0
+      '@algolia/requester-fetch': 5.56.0
+      '@algolia/requester-node-http': 5.56.0
+
+  '@algolia/ingestion@1.56.0':
+    dependencies:
+      '@algolia/client-common': 5.56.0
+      '@algolia/requester-browser-xhr': 5.56.0
+      '@algolia/requester-fetch': 5.56.0
+      '@algolia/requester-node-http': 5.56.0
+
+  '@algolia/monitoring@1.56.0':
+    dependencies:
+      '@algolia/client-common': 5.56.0
+      '@algolia/requester-browser-xhr': 5.56.0
+      '@algolia/requester-fetch': 5.56.0
+      '@algolia/requester-node-http': 5.56.0
+
+  '@algolia/recommend@5.56.0':
+    dependencies:
+      '@algolia/client-common': 5.56.0
+      '@algolia/requester-browser-xhr': 5.56.0
+      '@algolia/requester-fetch': 5.56.0
+      '@algolia/requester-node-http': 5.56.0
+
+  '@algolia/requester-browser-xhr@5.56.0':
+    dependencies:
+      '@algolia/client-common': 5.56.0
+
+  '@algolia/requester-fetch@5.56.0':
+    dependencies:
+      '@algolia/client-common': 5.56.0
+
+  '@algolia/requester-node-http@5.56.0':
+    dependencies:
+      '@algolia/client-common': 5.56.0
+
+  '@babel/helper-string-parser@7.29.7': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+
+  '@docsearch/css@3.8.2': {}
+
+  '@docsearch/js@3.8.2(@algolia/client-search@5.56.0)(search-insights@2.17.3)':
+    dependencies:
+      '@docsearch/react': 3.8.2(@algolia/client-search@5.56.0)(search-insights@2.17.3)
+      preact: 10.29.7
+    transitivePeerDependencies:
+      - '@algolia/client-search'
+      - '@types/react'
+      - preact-render-to-string
+      - react
+      - react-dom
+      - search-insights
+
+  '@docsearch/react@3.8.2(@algolia/client-search@5.56.0)(search-insights@2.17.3)':
+    dependencies:
+      '@algolia/autocomplete-core': 1.17.7(@algolia/client-search@5.56.0)(algoliasearch@5.56.0)(search-insights@2.17.3)
+      '@algolia/autocomplete-preset-algolia': 1.17.7(@algolia/client-search@5.56.0)(algoliasearch@5.56.0)
+      '@docsearch/css': 3.8.2
+      algoliasearch: 5.56.0
+    optionalDependencies:
+      search-insights: 2.17.3
+    transitivePeerDependencies:
+      - '@algolia/client-search'
 
   '@emnapi/core@1.11.1':
     dependencies:
@@ -1530,52 +2451,103 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
   '@esbuild/aix-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
     optional: true
 
   '@esbuild/android-arm64@0.28.1':
     optional: true
 
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
   '@esbuild/android-arm@0.28.1':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
     optional: true
 
   '@esbuild/android-x64@0.28.1':
     optional: true
 
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
   '@esbuild/darwin-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
     optional: true
 
   '@esbuild/darwin-x64@0.28.1':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
     optional: true
 
   '@esbuild/freebsd-x64@0.28.1':
     optional: true
 
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
   '@esbuild/linux-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
     optional: true
 
   '@esbuild/linux-arm@0.28.1':
     optional: true
 
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
   '@esbuild/linux-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
     optional: true
 
   '@esbuild/linux-loong64@0.28.1':
     optional: true
 
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
   '@esbuild/linux-mips64el@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
     optional: true
 
   '@esbuild/linux-ppc64@0.28.1':
     optional: true
 
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
   '@esbuild/linux-riscv64@0.28.1':
     optional: true
 
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
   '@esbuild/linux-s390x@0.28.1':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
     optional: true
 
   '@esbuild/linux-x64@0.28.1':
@@ -1584,10 +2556,16 @@ snapshots:
   '@esbuild/netbsd-arm64@0.28.1':
     optional: true
 
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
   '@esbuild/netbsd-x64@0.28.1':
     optional: true
 
   '@esbuild/openbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
     optional: true
 
   '@esbuild/openbsd-x64@0.28.1':
@@ -1596,13 +2574,25 @@ snapshots:
   '@esbuild/openharmony-arm64@0.28.1':
     optional: true
 
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
   '@esbuild/sunos-x64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
     optional: true
 
   '@esbuild/win32-arm64@0.28.1':
     optional: true
 
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
   '@esbuild/win32-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
     optional: true
 
   '@esbuild/win32-x64@0.28.1':
@@ -1659,6 +2649,12 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/retry@0.4.3': {}
+
+  '@iconify-json/simple-icons@1.2.91':
+    dependencies:
+      '@iconify/types': 2.0.0
+
+  '@iconify/types@2.0.0': {}
 
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
@@ -1727,6 +2723,121 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
+  '@rollup/rollup-android-arm-eabi@4.62.2':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.62.2':
+    optional: true
+
+  '@shikijs/core@2.5.0':
+    dependencies:
+      '@shikijs/engine-javascript': 2.5.0
+      '@shikijs/engine-oniguruma': 2.5.0
+      '@shikijs/types': 2.5.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.5
+      hast-util-to-html: 9.0.5
+
+  '@shikijs/engine-javascript@2.5.0':
+    dependencies:
+      '@shikijs/types': 2.5.0
+      '@shikijs/vscode-textmate': 10.0.2
+      oniguruma-to-es: 3.1.1
+
+  '@shikijs/engine-oniguruma@2.5.0':
+    dependencies:
+      '@shikijs/types': 2.5.0
+      '@shikijs/vscode-textmate': 10.0.2
+
+  '@shikijs/langs@2.5.0':
+    dependencies:
+      '@shikijs/types': 2.5.0
+
+  '@shikijs/themes@2.5.0':
+    dependencies:
+      '@shikijs/types': 2.5.0
+
+  '@shikijs/transformers@2.5.0':
+    dependencies:
+      '@shikijs/core': 2.5.0
+      '@shikijs/types': 2.5.0
+
+  '@shikijs/types@2.5.0':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.5
+
+  '@shikijs/vscode-textmate@10.0.2': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@tybys/wasm-util@0.10.3':
@@ -1745,11 +2856,32 @@ snapshots:
 
   '@types/estree@1.0.9': {}
 
+  '@types/hast@3.0.5':
+    dependencies:
+      '@types/unist': 3.0.3
+
   '@types/json-schema@7.0.15': {}
+
+  '@types/linkify-it@5.0.0': {}
+
+  '@types/markdown-it@14.1.2':
+    dependencies:
+      '@types/linkify-it': 5.0.0
+      '@types/mdurl': 2.0.0
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/mdurl@2.0.0': {}
 
   '@types/node@25.9.5':
     dependencies:
       undici-types: 7.24.6
+
+  '@types/unist@3.0.3': {}
+
+  '@types/web-bluetooth@0.0.21': {}
 
   '@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@7.0.2))(eslint@10.8.0)(typescript@7.0.2)':
     dependencies:
@@ -1902,6 +3034,13 @@ snapshots:
   '@typescript/typescript-win32-x64@7.0.2':
     optional: true
 
+  '@ungap/structured-clone@1.3.3': {}
+
+  '@vitejs/plugin-vue@5.2.4(vite@5.4.21(@types/node@25.9.5)(lightningcss@1.33.0))(vue@3.5.40(typescript@7.0.2))':
+    dependencies:
+      vite: 5.4.21(@types/node@25.9.5)(lightningcss@1.33.0)
+      vue: 3.5.40(typescript@7.0.2)
+
   '@vitest/expect@4.1.10':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -1943,6 +3082,105 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  '@vue/compiler-core@3.5.40':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@vue/shared': 3.5.40
+      entities: 7.0.1
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
+
+  '@vue/compiler-dom@3.5.40':
+    dependencies:
+      '@vue/compiler-core': 3.5.40
+      '@vue/shared': 3.5.40
+
+  '@vue/compiler-sfc@3.5.40':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@vue/compiler-core': 3.5.40
+      '@vue/compiler-dom': 3.5.40
+      '@vue/compiler-ssr': 3.5.40
+      '@vue/shared': 3.5.40
+      estree-walker: 2.0.2
+      magic-string: 0.30.21
+      postcss: 8.5.22
+      source-map-js: 1.2.1
+
+  '@vue/compiler-ssr@3.5.40':
+    dependencies:
+      '@vue/compiler-dom': 3.5.40
+      '@vue/shared': 3.5.40
+
+  '@vue/devtools-api@7.7.10':
+    dependencies:
+      '@vue/devtools-kit': 7.7.10
+
+  '@vue/devtools-kit@7.7.10':
+    dependencies:
+      '@vue/devtools-shared': 7.7.10
+      birpc: 2.9.0
+      hookable: 5.5.3
+      mitt: 3.0.1
+      perfect-debounce: 1.0.0
+      speakingurl: 14.0.1
+      superjson: 2.2.6
+
+  '@vue/devtools-shared@7.7.10':
+    dependencies:
+      rfdc: 1.4.1
+
+  '@vue/reactivity@3.5.40':
+    dependencies:
+      '@vue/shared': 3.5.40
+
+  '@vue/runtime-core@3.5.40':
+    dependencies:
+      '@vue/reactivity': 3.5.40
+      '@vue/shared': 3.5.40
+
+  '@vue/runtime-dom@3.5.40':
+    dependencies:
+      '@vue/reactivity': 3.5.40
+      '@vue/runtime-core': 3.5.40
+      '@vue/shared': 3.5.40
+      csstype: 3.2.3
+
+  '@vue/server-renderer@3.5.40':
+    dependencies:
+      '@vue/compiler-ssr': 3.5.40
+      '@vue/runtime-dom': 3.5.40
+      '@vue/shared': 3.5.40
+
+  '@vue/shared@3.5.40': {}
+
+  '@vueuse/core@12.8.2(typescript@7.0.2)':
+    dependencies:
+      '@types/web-bluetooth': 0.0.21
+      '@vueuse/metadata': 12.8.2
+      '@vueuse/shared': 12.8.2(typescript@7.0.2)
+      vue: 3.5.40(typescript@7.0.2)
+    transitivePeerDependencies:
+      - typescript
+
+  '@vueuse/integrations@12.8.2(focus-trap@7.8.0)(typescript@7.0.2)':
+    dependencies:
+      '@vueuse/core': 12.8.2(typescript@7.0.2)
+      '@vueuse/shared': 12.8.2(typescript@7.0.2)
+      vue: 3.5.40(typescript@7.0.2)
+    optionalDependencies:
+      focus-trap: 7.8.0
+    transitivePeerDependencies:
+      - typescript
+
+  '@vueuse/metadata@12.8.2': {}
+
+  '@vueuse/shared@12.8.2(typescript@7.0.2)':
+    dependencies:
+      vue: 3.5.40(typescript@7.0.2)
+    transitivePeerDependencies:
+      - typescript
+
   abbrev@4.0.0:
     optional: true
 
@@ -1958,6 +3196,23 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  algoliasearch@5.56.0:
+    dependencies:
+      '@algolia/abtesting': 1.22.0
+      '@algolia/client-abtesting': 5.56.0
+      '@algolia/client-analytics': 5.56.0
+      '@algolia/client-common': 5.56.0
+      '@algolia/client-insights': 5.56.0
+      '@algolia/client-personalization': 5.56.0
+      '@algolia/client-query-suggestions': 5.56.0
+      '@algolia/client-search': 5.56.0
+      '@algolia/ingestion': 1.56.0
+      '@algolia/monitoring': 1.56.0
+      '@algolia/recommend': 5.56.0
+      '@algolia/requester-browser-xhr': 5.56.0
+      '@algolia/requester-fetch': 5.56.0
+      '@algolia/requester-node-http': 5.56.0
 
   assertion-error@2.0.1: {}
 
@@ -1977,6 +3232,8 @@ snapshots:
       file-uri-to-path: 1.0.0
     optional: true
 
+  birpc@2.9.0: {}
+
   bl@4.1.0:
     dependencies:
       buffer: 5.7.1
@@ -1994,7 +3251,13 @@ snapshots:
       ieee754: 1.2.1
     optional: true
 
+  ccount@2.0.1: {}
+
   chai@6.2.2: {}
+
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
 
   chownr@1.1.4:
     optional: true
@@ -2004,15 +3267,23 @@ snapshots:
 
   colorette@2.0.19: {}
 
+  comma-separated-tokens@2.0.3: {}
+
   commander@10.0.1: {}
 
   convert-source-map@2.0.0: {}
+
+  copy-anything@4.0.5:
+    dependencies:
+      is-what: 5.5.0
 
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  csstype@3.2.3: {}
 
   debug@4.3.4:
     dependencies:
@@ -2034,14 +3305,24 @@ snapshots:
 
   denque@2.1.0: {}
 
+  dequal@2.0.3: {}
+
   detect-libc@2.1.2: {}
 
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
+
   dotenv@17.4.2: {}
+
+  emoji-regex-xs@1.0.0: {}
 
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
     optional: true
+
+  entities@7.0.1: {}
 
   env-paths@2.2.1:
     optional: true
@@ -2049,6 +3330,32 @@ snapshots:
   es-errors@1.3.0: {}
 
   es-module-lexer@2.3.1: {}
+
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
 
   esbuild@0.28.1:
     optionalDependencies:
@@ -2147,6 +3454,8 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@2.0.2: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.9
@@ -2190,6 +3499,10 @@ snapshots:
 
   flatted@3.4.3: {}
 
+  focus-trap@7.8.0:
+    dependencies:
+      tabbable: 6.5.0
+
   fs-constants@1.0.0:
     optional: true
 
@@ -2219,6 +3532,28 @@ snapshots:
   hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
+
+  hast-util-to-html@9.0.5:
+    dependencies:
+      '@types/hast': 3.0.5
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      comma-separated-tokens: 2.0.3
+      hast-util-whitespace: 3.0.0
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      property-information: 7.2.0
+      space-separated-tokens: 2.0.2
+      stringify-entities: 4.0.4
+      zwitch: 2.0.4
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.5
+
+  hookable@5.5.3: {}
+
+  html-void-elements@3.0.0: {}
 
   iconv-lite@0.7.3:
     dependencies:
@@ -2252,6 +3587,8 @@ snapshots:
       is-extglob: 2.1.1
 
   is-property@1.0.2: {}
+
+  is-what@5.5.0: {}
 
   isexe@2.0.0: {}
 
@@ -2359,6 +3696,37 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  mark.js@8.11.1: {}
+
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.3
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
   mimic-response@3.1.0:
     optional: true
 
@@ -2372,10 +3740,14 @@ snapshots:
   minipass@7.1.3:
     optional: true
 
+  minisearch@7.2.0: {}
+
   minizlib@3.1.0:
     dependencies:
       minipass: 7.1.3
     optional: true
+
+  mitt@3.0.1: {}
 
   mkdirp-classic@0.5.3:
     optional: true
@@ -2440,6 +3812,12 @@ snapshots:
       wrappy: 1.0.2
     optional: true
 
+  oniguruma-to-es@3.1.1:
+    dependencies:
+      emoji-regex-xs: 1.0.0
+      regex: 6.1.0
+      regex-recursion: 6.0.2
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -2465,6 +3843,8 @@ snapshots:
 
   pathe@2.0.3: {}
 
+  perfect-debounce@1.0.0: {}
+
   pg-connection-string@2.6.2: {}
 
   picocolors@1.1.1: {}
@@ -2478,6 +3858,8 @@ snapshots:
       nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  preact@10.29.7: {}
 
   prebuild-install@7.1.3:
     dependencies:
@@ -2499,6 +3881,8 @@ snapshots:
 
   proc-log@6.1.0:
     optional: true
+
+  property-information@7.2.0: {}
 
   pump@3.0.4:
     dependencies:
@@ -2527,6 +3911,16 @@ snapshots:
     dependencies:
       resolve: 1.22.12
 
+  regex-recursion@6.0.2:
+    dependencies:
+      regex-utilities: 2.3.0
+
+  regex-utilities@2.3.0: {}
+
+  regex@6.1.0:
+    dependencies:
+      regex-utilities: 2.3.0
+
   resolve-from@5.0.0: {}
 
   resolve@1.22.12:
@@ -2535,6 +3929,8 @@ snapshots:
       is-core-module: 2.16.2
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
+
+  rfdc@1.4.1: {}
 
   rolldown@1.1.5:
     dependencies:
@@ -2557,10 +3953,43 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.1.5
       '@rolldown/binding-win32-x64-msvc': 1.1.5
 
+  rollup@4.62.2:
+    dependencies:
+      '@types/estree': 1.0.9
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.62.2
+      '@rollup/rollup-android-arm64': 4.62.2
+      '@rollup/rollup-darwin-arm64': 4.62.2
+      '@rollup/rollup-darwin-x64': 4.62.2
+      '@rollup/rollup-freebsd-arm64': 4.62.2
+      '@rollup/rollup-freebsd-x64': 4.62.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.62.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.62.2
+      '@rollup/rollup-linux-arm64-gnu': 4.62.2
+      '@rollup/rollup-linux-arm64-musl': 4.62.2
+      '@rollup/rollup-linux-loong64-gnu': 4.62.2
+      '@rollup/rollup-linux-loong64-musl': 4.62.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.62.2
+      '@rollup/rollup-linux-ppc64-musl': 4.62.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.62.2
+      '@rollup/rollup-linux-riscv64-musl': 4.62.2
+      '@rollup/rollup-linux-s390x-gnu': 4.62.2
+      '@rollup/rollup-linux-x64-gnu': 4.62.2
+      '@rollup/rollup-linux-x64-musl': 4.62.2
+      '@rollup/rollup-openbsd-x64': 4.62.2
+      '@rollup/rollup-openharmony-arm64': 4.62.2
+      '@rollup/rollup-win32-arm64-msvc': 4.62.2
+      '@rollup/rollup-win32-ia32-msvc': 4.62.2
+      '@rollup/rollup-win32-x64-gnu': 4.62.2
+      '@rollup/rollup-win32-x64-msvc': 4.62.2
+      fsevents: 2.3.3
+
   safe-buffer@5.2.1:
     optional: true
 
   safer-buffer@2.1.2: {}
+
+  search-insights@2.17.3: {}
 
   semver@7.8.5: {}
 
@@ -2569,6 +3998,17 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  shiki@2.5.0:
+    dependencies:
+      '@shikijs/core': 2.5.0
+      '@shikijs/engine-javascript': 2.5.0
+      '@shikijs/engine-oniguruma': 2.5.0
+      '@shikijs/langs': 2.5.0
+      '@shikijs/themes': 2.5.0
+      '@shikijs/types': 2.5.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.5
 
   siginfo@2.0.0: {}
 
@@ -2583,6 +4023,10 @@ snapshots:
     optional: true
 
   source-map-js@1.2.1: {}
+
+  space-separated-tokens@2.0.2: {}
+
+  speakingurl@14.0.1: {}
 
   sql-escaper@1.5.1: {}
 
@@ -2605,10 +4049,21 @@ snapshots:
       safe-buffer: 5.2.1
     optional: true
 
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
+
   strip-json-comments@2.0.1:
     optional: true
 
+  superjson@2.2.6:
+    dependencies:
+      copy-anything: 4.0.5
+
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  tabbable@6.5.0: {}
 
   tar-fs@2.1.5:
     dependencies:
@@ -2650,6 +4105,8 @@ snapshots:
       picomatch: 4.0.5
 
   tinyrainbow@3.1.0: {}
+
+  trim-lines@3.0.1: {}
 
   ts-api-utils@2.5.0(typescript@7.0.2):
     dependencies:
@@ -2712,12 +4169,55 @@ snapshots:
   undici@6.28.0:
     optional: true
 
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
 
   util-deprecate@1.0.2:
     optional: true
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
+
+  vite@5.4.21(@types/node@25.9.5)(lightningcss@1.33.0):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.22
+      rollup: 4.62.2
+    optionalDependencies:
+      '@types/node': 25.9.5
+      fsevents: 2.3.3
+      lightningcss: 1.33.0
 
   vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(tsx@4.23.1):
     dependencies:
@@ -2731,6 +4231,56 @@ snapshots:
       esbuild: 0.28.1
       fsevents: 2.3.3
       tsx: 4.23.1
+
+  vitepress@1.6.4(@algolia/client-search@5.56.0)(@types/node@25.9.5)(lightningcss@1.33.0)(postcss@8.5.22)(search-insights@2.17.3)(typescript@7.0.2):
+    dependencies:
+      '@docsearch/css': 3.8.2
+      '@docsearch/js': 3.8.2(@algolia/client-search@5.56.0)(search-insights@2.17.3)
+      '@iconify-json/simple-icons': 1.2.91
+      '@shikijs/core': 2.5.0
+      '@shikijs/transformers': 2.5.0
+      '@shikijs/types': 2.5.0
+      '@types/markdown-it': 14.1.2
+      '@vitejs/plugin-vue': 5.2.4(vite@5.4.21(@types/node@25.9.5)(lightningcss@1.33.0))(vue@3.5.40(typescript@7.0.2))
+      '@vue/devtools-api': 7.7.10
+      '@vue/shared': 3.5.40
+      '@vueuse/core': 12.8.2(typescript@7.0.2)
+      '@vueuse/integrations': 12.8.2(focus-trap@7.8.0)(typescript@7.0.2)
+      focus-trap: 7.8.0
+      mark.js: 8.11.1
+      minisearch: 7.2.0
+      shiki: 2.5.0
+      vite: 5.4.21(@types/node@25.9.5)(lightningcss@1.33.0)
+      vue: 3.5.40(typescript@7.0.2)
+    optionalDependencies:
+      postcss: 8.5.22
+    transitivePeerDependencies:
+      - '@algolia/client-search'
+      - '@types/node'
+      - '@types/react'
+      - async-validator
+      - axios
+      - change-case
+      - drauu
+      - fuse.js
+      - idb-keyval
+      - jwt-decode
+      - less
+      - lightningcss
+      - nprogress
+      - preact-render-to-string
+      - qrcode
+      - react
+      - react-dom
+      - sass
+      - sass-embedded
+      - search-insights
+      - sortablejs
+      - stylus
+      - sugarss
+      - terser
+      - typescript
+      - universal-cookie
 
   vitest@4.1.10(@types/node@25.9.5)(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(tsx@4.23.1)):
     dependencies:
@@ -2759,6 +4309,16 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
+  vue@3.5.40(typescript@7.0.2):
+    dependencies:
+      '@vue/compiler-dom': 3.5.40
+      '@vue/compiler-sfc': 3.5.40
+      '@vue/runtime-dom': 3.5.40
+      '@vue/server-renderer': 3.5.40
+      '@vue/shared': 3.5.40
+    optionalDependencies:
+      typescript: 7.0.2
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
@@ -2782,3 +4342,5 @@ snapshots:
     optional: true
 
   yocto-queue@0.1.0: {}
+
+  zwitch@2.0.4: {}


### PR DESCRIPTION
## Summary

- Add a VitePress docs site under `docs/` with guides (configuration, models, queries, relationships, migrations, Express, Nuxt, security) and API reference pages, including practical examples.
- Install VitePress and add `docs:dev` / `docs:build` / `docs:preview` scripts; set `base: '/mevn-orm/'` for GitHub project Pages.
- Add `.github/workflows/docs.yml` to build and deploy to GitHub Pages from `main`.
- Mark `docs/**` as `linguist-documentation`, ignore VitePress build/cache output, and point package `homepage` / README at the docs site.

## After merge (repo settings)

1. **Settings → Pages → Source** → **GitHub Actions**
2. Approve the first deploy if the `github-pages` environment requires it
3. Site: https://stanleymasinde.github.io/mevn-orm/

## Test plan

- [x] `pnpm run docs:build` succeeds locally
- [x] Workflow runs after merge (or via `workflow_dispatch`)
- [x] Pages site loads with working CSS and navigation under `/mevn-orm/`